### PR TITLE
Site redesign + /guide section (App Store launch prep)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-ifly-site-redesign-guide.md
+++ b/docs/superpowers/plans/2026-07-02-ifly-site-redesign-guide.md
@@ -1,0 +1,1699 @@
+# iFly Website Redesign + Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the iFly Next.js site with a provenance-emu-inspired retrowave design system (kept orange) and add a multi-page `/guide` section covering importing, formats, BIOS, arcade rips, systems, and FAQ — ready for the first App Store release.
+
+**Architecture:** Add a token layer to `globals.css` (Tailwind v4 `@theme` + CSS custom properties + keyframes) and a small reusable component library under `src/components/ui/`. Restyle nav/footer/pages and build the `/guide` route group on top of those components. No stack change; static export stays intact.
+
+**Tech Stack:** Next.js 16 App Router · React 19 · Tailwind v4 (PostCSS) · TypeScript · `output: 'export'` static export.
+
+## Global Constraints
+
+- **No test suite exists.** Verification per task = `npm run type-check` && `npm run lint` && `npm run build` all pass, plus a render check via `npm run dev`. There is no pytest/jest cycle.
+- **Static export only:** `output: 'export'`, `trailingSlash: true`, `images: { unoptimized: true }`. No server-only features. API routes stay `export const dynamic = 'force-static'`.
+- **`'use client'` components cannot export `metadata`.** Interactive pieces (accordion) are client children imported by server pages.
+- **Every page exports `metadata`** with `title`, `description`, and `alternates.canonical` (`https://ifly-emu.com/<path>/` with trailing slash).
+- **Brand:** primary orange `#ff6900`. Primary gradient `linear-gradient(135deg, #ffab40 0%, #ff6900 50%, #d64500 100%)`. Layered near-black backgrounds `#0a0a0f` / `#0d0d14` / `#111119`.
+- **Copy follows `~/Workspace/personal-os/VOICE.md`:** backticks around every identifier/extension/filename/path; specific numbers; no marketing speak; no closing-summary paragraphs; banned-phrase + soft-vocab lists apply; em-dash cap 2/1000 words. Homepage hero may read slightly more "marketing" (approved exception); guide/FAQ copy stays factual.
+- **Path alias:** `@/*` → `./src/*`.
+- **New routes** must be added to `src/app/sitemap.ts`.
+- **CSP:** do not introduce new external origins (would require editing the CSP in `src/app/layout.tsx`). All new assets are same-origin.
+- **Branch:** all work on `redesign/site-guide` (already created). Commit after each task.
+
+---
+
+## Facts reference (for content tasks — source-verified from the iFly repo)
+
+**Supported extensions:**
+- Standalone disc: `.iso`, `.cdi`, `.chd`
+- Index-based: `.gdi` (→ `.bin`/`.raw`/`.img` tracks), `.cue` (→ `.bin`)
+- Payload/tracks: `.bin`, `.raw`, `.img`, `.dat`, `.lst`
+- Playlist: `.m3u` (multi-disc)
+- Homebrew: `.elf`
+- Archives: `.zip`, `.7z`
+- Skins: `.deltaskin`, `.manicskin`, `.skin`, `.emuskin`
+
+**Systems:** Dreamcast, Naomi, Naomi 2, Atomiswave, System SP ("Spider"), plus game-specific boards (House of the Dead 2, Ferrari F355, Airline Pilots).
+
+**BIOS matrix:**
+| System | File | Required? | Notes |
+|--------|------|-----------|-------|
+| Dreamcast | `dc_boot.bin` | Optional | Boot animation; HLE BIOS (Reios) used by default |
+| Dreamcast | `dc_flash.bin` | Optional | Flash/NVRAM; pair with `dc_boot.bin` for full accuracy |
+| Naomi | `naomi.zip` | Required | MAME romset; basename must match |
+| Naomi 2 | `naomi2.zip` | Required | MAME romset |
+| Atomiswave | `awbios.zip` | Required | MAME romset |
+| System SP | `segasp.zip` | Required | MAME romset |
+| House of the Dead 2 | `hod2bios.zip` | Optional | Game-specific board |
+| Ferrari F355 | `f355bios.zip` / `f355dlx.zip` | Optional | Challenge / Deluxe |
+| Airline Pilots | `airlbios.zip` | Optional | Also Sega Strike Fighter |
+
+BIOS live in the `BIOS/` folder (case-normalized to lowercase). Storage: `ROMs/`, `BIOS/`, `Skins/`.
+
+**Arcade rip handling (iFly's edge over stock Flycast):**
+- Single decrypted `.bin`/`.dat` cart in an archive with **no** `.ic*` chip files (archive.org style, e.g. `VirtuaFighter4.zip` → `VirtuaFighter4.bin`) → iFly routes to the decrypted-ROM path; Flycast peeks the board header (`NAOMI`/`Naomi2`) to auto-select BIOS. Stock Flycast fails these.
+- Multi-track GD-ROM dumps (`.cue` + multiple `.bin`) → detected as a disc, extracted, all tracks verified present.
+- Naomi GD-cartridge zip+CHD companion: `senkosp.zip` + `senkosp/gdl-0030a.chd` → iFly carries the sibling CHD alongside the cart zip and warns if it is missing.
+- MAME chip-set zips (contain `.ic*`) → copied as-is, opened by the MAME loader.
+
+**Import methods:** Files app / document picker; drag-and-drop (iPad, iOS 15+); Wi-Fi WebDAV upload with QR (iOS/tvOS/macOS); `ifly://` URL scheme. Disc archives (`.zip`/`.7z` containing `.gdi`/`.cue`) are extracted; arcade romsets copied as-is; extraction is all-or-nothing with rollback.
+
+**Format recommendation:** prefer `.chd` (compressed, ~700 MB → ~300 MB, single file) or `.cdi` (single file) over `.gdi` (multi-file, breaks if a track is missing).
+
+**Feature list (grouped) — for Tasks 13/14:**
+- *Performance & graphics:* custom Metal backend; custom Apple-silicon CPU work → JIT-less full-speed emulation, upscaling to `1440p`/`4K` (e.g. iPhone 16 Pro Max); `1K+` Metal shaders; HDR "upscaling"; custom texture-pack support with management UI; ProMotion high-refresh + original-rate locking.
+- *VMU tooling:* floating VMU window; VMU Watch companion (live viewer on Apple Watch); custom Swift-native VMU file manager with per-game / per-VMU backup and restore.
+- *Saves & sync:* iCloud sync of saves, VMUs, BIOS — **not** ROMs; auto timed saves via off-main-thread save-state serialization (no emulation stall); HLE and native BIOS support.
+- *Input & controls:* external controller haptics; Jump Pack rumble → device haptics or controller rumble (DualShock, DualSense, Xbox); touch light-gun; on-screen touch keyboard/mouse + native Bluetooth keyboard/mouse & Smart Keyboard where the OS supports it; native CoreAudio microphone input; customizable movable on-screen controls; remappable controller buttons with presets; DeltaSkin / ManicSkin skins.
+- *Connectivity & display:* external display support (iOS/iPadOS); DCNet network and LAN support (what Flycast supports).
+- *Games & content:* in-app cheat-code database; RetroAchievements; online game-metadata lookup; per-game options tuning.
+- *Import:* WebDAV, HTTP, or Files.app import; drag-and-drop on iPad.
+- *Platform & convenience:* iOS / iPadOS / tvOS; quick-launch recent-games Springboard widget.
+
+---
+
+## File Structure
+
+**Create**
+- `src/components/ui/Section.tsx` — layout wrapper (container + vertical rhythm + optional bg tone).
+- `src/components/ui/Card.tsx` — glass card + `FeatureCard` (icon box + title + copy).
+- `src/components/ui/GradientButton.tsx` — orange gradient pill (Link or `<a>`).
+- `src/components/ui/Badge.tsx` — `Badge` + `Pill` small labels.
+- `src/components/ui/Callout.tsx` — tip/warn/info note box.
+- `src/components/ui/Screenshot.tsx` — placeholder-aware image slot.
+- `src/components/ui/GridHero.tsx` — full-bleed hero with animated grid + glow.
+- `src/components/ui/PageHeader.tsx` — interior-page header (grid-lite, no CTAs).
+- `src/components/ui/Accordion.tsx` — `'use client'` collapsible list.
+- `src/app/guide/layout.tsx` — guide shell + sub-nav + prev/next.
+- `src/app/guide/guideNav.ts` — shared ordered list of guide pages (data).
+- `src/app/guide/page.tsx` — guide index.
+- `src/app/guide/importing/page.tsx`
+- `src/app/guide/formats/page.tsx`
+- `src/app/guide/bios/page.tsx`
+- `src/app/guide/arcade/page.tsx`
+- `src/app/guide/systems/page.tsx`
+- `src/app/guide/faq/page.tsx`
+- `src/app/guide/faq/FaqAccordion.tsx` — `'use client'` FAQ data + Accordion usage.
+
+**Modify**
+- `src/app/globals.css` — tokens, keyframes, utilities.
+- `src/components/Navigation.tsx` — glassmorphism + Guide item.
+- `src/components/Footer.tsx` — add Guide links, retune tones.
+- `src/components/Features.tsx` — new grouped feature set.
+- `src/components/ButtonLink.tsx` — keep API, restyle to gradient (optional; GradientButton is the primary path).
+- `src/app/page.tsx` — homepage restyle + highlights.
+- Existing pages: `downloads`, `about`, `features`, `support`, `links`, `donate`, `status`, `controllers`, `privacy`, `licenses`, `testflight`, `testflight-patrons` — restyle onto new components.
+- `src/app/sitemap.ts` — add 7 guide routes.
+
+---
+
+## Task 1: Design tokens, keyframes, and utilities
+
+**Files:**
+- Modify: `src/app/globals.css`
+
+**Interfaces:**
+- Produces: CSS utility classes `.text-gradient`, `.grid-overlay`, `.card-glass`, `.btn-gradient`, `.btn-gradient:hover`; CSS vars `--gradient-primary`, `--gradient-primary-hover`, `--ease-smooth`, `--radius-card`, `--shadow-sm/md/lg`; theme colors `--color-ink`, `--color-ink-2`, `--color-ink-3`; keyframe `grid-drift`.
+
+- [ ] **Step 1: Replace `globals.css` with the token layer**
+
+```css
+@import "tailwindcss";
+
+@theme inline {
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  --font-mono: 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+
+  /* Layered near-black backgrounds (exposes bg-ink / bg-ink-2 / bg-ink-3 utilities) */
+  --color-ink: #0a0a0f;
+  --color-ink-2: #0d0d14;
+  --color-ink-3: #111119;
+}
+
+:root {
+  --gradient-primary: linear-gradient(135deg, #ffab40 0%, #ff6900 50%, #d64500 100%);
+  --gradient-primary-hover: linear-gradient(135deg, #ffbe5c 0%, #ff7d1f 50%, #f0530f 100%);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+  --radius-card: 12px;
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.55);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.65);
+}
+
+body {
+  background-color: var(--color-ink);
+  color: #ededed;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+h1, h2 { letter-spacing: -0.02em; }
+
+/* Gradient text (orange). Apply to a span/heading. */
+.text-gradient {
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Animated drifting grid overlay — absolute child of a relative hero. */
+.grid-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 105, 0, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 105, 0, 0.08) 1px, transparent 1px);
+  background-size: 40px 40px;
+  animation: grid-drift 22s linear infinite;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%);
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%);
+}
+
+@keyframes grid-drift {
+  from { background-position: 0 0, 0 0; }
+  to   { background-position: 40px 40px, 40px 40px; }
+}
+
+/* Glass card */
+.card-glass {
+  background-color: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-card);
+  transition: transform 0.3s var(--ease-smooth), box-shadow 0.3s var(--ease-smooth), border-color 0.3s var(--ease-smooth);
+}
+.card-glass:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+  border-color: rgba(255, 105, 0, 0.35);
+}
+
+/* Gradient pill button */
+.btn-gradient {
+  position: relative;
+  background: var(--gradient-primary);
+  color: #fff;
+  border-radius: 9999px;
+  transition: transform 0.3s var(--ease-smooth), box-shadow 0.3s var(--ease-smooth), filter 0.3s var(--ease-smooth);
+  box-shadow: 0 6px 20px rgba(255, 105, 0, 0.25);
+}
+.btn-gradient:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.08);
+  box-shadow: 0 10px 28px rgba(255, 105, 0, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grid-overlay { animation: none; }
+  .card-glass:hover, .btn-gradient:hover { transform: none; }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run type-check && npm run build`
+Expected: build succeeds, static export to `out/`. (CSS-only change; no type impact.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/globals.css
+git commit -m "feat(ui): add retrowave design tokens, keyframes, and utility classes"
+```
+
+---
+
+## Task 2: Primitive UI components
+
+**Files:**
+- Create: `src/components/ui/Section.tsx`, `src/components/ui/Card.tsx`, `src/components/ui/GradientButton.tsx`, `src/components/ui/Badge.tsx`, `src/components/ui/Callout.tsx`, `src/components/ui/Screenshot.tsx`
+
+**Interfaces:**
+- Produces:
+  - `Section({ children, className, tone, id }: { children: React.ReactNode; className?: string; tone?: 'ink' | 'ink-2' | 'ink-3'; id?: string })`
+  - `Card({ children, className })`; `FeatureCard({ icon, title, children, className })` (named exports from `Card.tsx`; `Card` default)
+  - `GradientButton({ href, children, external?, className?, variant? })` — `variant?: 'solid' | 'outline'` (default `'solid'`)
+  - `Badge({ children, tone })` (`tone?: 'default' | 'required' | 'optional'`) + `Pill({ children })` from `Badge.tsx`
+  - `Callout({ variant, title, children })` (`variant: 'tip' | 'warn' | 'info'`)
+  - `Screenshot({ src?, alt, caption?, width, height, className? })`
+
+- [ ] **Step 1: Create `src/components/ui/Section.tsx`**
+
+```tsx
+import React from 'react';
+
+const toneClass = {
+  ink: 'bg-ink',
+  'ink-2': 'bg-ink-2',
+  'ink-3': 'bg-ink-3',
+} as const;
+
+type SectionProps = {
+  children: React.ReactNode;
+  className?: string;
+  tone?: keyof typeof toneClass;
+  id?: string;
+};
+
+export default function Section({ children, className = '', tone, id }: SectionProps) {
+  return (
+    <section id={id} className={`${tone ? toneClass[tone] : ''} py-16 ${className}`}>
+      <div className="container mx-auto px-4">{children}</div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/components/ui/Card.tsx`**
+
+```tsx
+import React from 'react';
+
+export default function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return <div className={`card-glass p-6 ${className}`}>{children}</div>;
+}
+
+export function FeatureCard({
+  icon,
+  title,
+  children,
+  className = '',
+}: {
+  icon?: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`card-glass group flex flex-col gap-4 p-6 ${className}`}>
+      {icon && (
+        <div
+          aria-hidden="true"
+          className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-orange-500/10 text-orange-400 ring-1 ring-orange-500/20 transition-colors duration-300 group-hover:bg-[image:var(--gradient-primary)] group-hover:text-white group-hover:ring-transparent"
+        >
+          {icon}
+        </div>
+      )}
+      <div>
+        <h3 className="mb-1.5 text-lg font-semibold text-white">{title}</h3>
+        <p className="text-sm leading-relaxed text-gray-400">{children}</p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `src/components/ui/GradientButton.tsx`**
+
+```tsx
+import Link from 'next/link';
+import React from 'react';
+
+type GradientButtonProps = {
+  href: string;
+  children: React.ReactNode;
+  external?: boolean;
+  className?: string;
+  variant?: 'solid' | 'outline';
+};
+
+const base = 'inline-flex items-center justify-center gap-2 px-8 py-3 font-semibold text-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 focus-visible:ring-offset-ink';
+const solid = 'btn-gradient';
+const outline = 'rounded-full border border-orange-500/50 text-orange-300 hover:bg-orange-500/10 transition-colors';
+
+export default function GradientButton({ href, children, external = false, className = '', variant = 'solid' }: GradientButtonProps) {
+  const classes = `${base} ${variant === 'solid' ? solid : outline} ${className}`;
+  if (external) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={classes}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className={classes}>
+      {children}
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4: Create `src/components/ui/Badge.tsx`**
+
+```tsx
+import React from 'react';
+
+const toneClass = {
+  default: 'bg-gray-800 text-gray-300 border-gray-700',
+  required: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  optional: 'bg-gray-800 text-gray-400 border-gray-700',
+} as const;
+
+export function Badge({ children, tone = 'default' }: { children: React.ReactNode; tone?: keyof typeof toneClass }) {
+  return (
+    <span className={`inline-block rounded-full border px-3 py-1 text-xs font-medium ${toneClass[tone]}`}>
+      {children}
+    </span>
+  );
+}
+
+export function Pill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-block rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-sm text-gray-300">
+      {children}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 5: Create `src/components/ui/Callout.tsx`**
+
+```tsx
+import React from 'react';
+
+const variantClass = {
+  tip: 'border-orange-500/30 bg-orange-500/[0.06]',
+  warn: 'border-amber-500/30 bg-amber-500/[0.06]',
+  info: 'border-sky-500/30 bg-sky-500/[0.06]',
+} as const;
+
+const labelClass = {
+  tip: 'text-orange-300',
+  warn: 'text-amber-300',
+  info: 'text-sky-300',
+} as const;
+
+export default function Callout({
+  variant = 'info',
+  title,
+  children,
+}: {
+  variant?: keyof typeof variantClass;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`my-6 rounded-xl border p-4 ${variantClass[variant]}`}>
+      {title && <p className={`mb-1 text-sm font-semibold ${labelClass[variant]}`}>{title}</p>}
+      <div className="text-sm leading-relaxed text-gray-300">{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Create `src/components/ui/Screenshot.tsx`**
+
+```tsx
+import Image from 'next/image';
+import React from 'react';
+
+type ScreenshotProps = {
+  src?: string;
+  alt: string;
+  caption?: string;
+  width: number;
+  height: number;
+  className?: string;
+};
+
+export default function Screenshot({ src, alt, caption, width, height, className = '' }: ScreenshotProps) {
+  return (
+    <figure className={className}>
+      {src ? (
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          className="rounded-xl border border-white/10 shadow-lg"
+        />
+      ) : (
+        <div
+          role="img"
+          aria-label={`Placeholder: ${alt}`}
+          style={{ aspectRatio: `${width} / ${height}` }}
+          className="flex w-full flex-col items-center justify-center gap-1 rounded-xl border border-dashed border-white/15 bg-white/[0.02] p-6 text-center"
+        >
+          <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Screenshot</span>
+          <span className="text-sm text-gray-400">{alt}</span>
+          <span className="text-[11px] text-gray-600">{width}×{height}</span>
+        </div>
+      )}
+      {caption && <figcaption className="mt-2 text-center text-xs text-gray-500">{caption}</figcaption>}
+    </figure>
+  );
+}
+```
+
+- [ ] **Step 7: Verify**
+
+Run: `npm run type-check && npm run lint && npm run build`
+Expected: all pass. (Components unused so far; build still succeeds.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/ui/Section.tsx src/components/ui/Card.tsx src/components/ui/GradientButton.tsx src/components/ui/Badge.tsx src/components/ui/Callout.tsx src/components/ui/Screenshot.tsx
+git commit -m "feat(ui): add Section, Card, GradientButton, Badge, Callout, Screenshot primitives"
+```
+
+---
+
+## Task 3: Hero components
+
+**Files:**
+- Create: `src/components/ui/GridHero.tsx`, `src/components/ui/PageHeader.tsx`
+
+**Interfaces:**
+- Consumes: `.grid-overlay` (Task 1).
+- Produces:
+  - `GridHero({ children, className })` — relative section with grid overlay + orange radial glow; caller supplies centered content.
+  - `PageHeader({ title, subtitle, eyebrow? })` — interior page header.
+
+- [ ] **Step 1: Create `src/components/ui/GridHero.tsx`**
+
+```tsx
+import React from 'react';
+
+export default function GridHero({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return (
+    <section className={`relative overflow-hidden ${className}`}>
+      <div className="grid-overlay" aria-hidden="true" />
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
+        <div className="absolute left-1/2 top-0 h-[600px] w-[900px] -translate-x-1/2 rounded-full bg-orange-500/10 blur-3xl" />
+        <div className="absolute left-1/2 top-20 h-[400px] w-[400px] -translate-x-1/2 rounded-full bg-orange-600/5 blur-2xl" />
+      </div>
+      <div className="container relative mx-auto px-4">{children}</div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/components/ui/PageHeader.tsx`**
+
+```tsx
+import React from 'react';
+import GridHero from './GridHero';
+
+export default function PageHeader({
+  title,
+  subtitle,
+  eyebrow,
+}: {
+  title: string;
+  subtitle?: string;
+  eyebrow?: string;
+}) {
+  return (
+    <GridHero className="pt-16 pb-10 text-center">
+      <div className="mx-auto max-w-3xl">
+        {eyebrow && <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-orange-400">{eyebrow}</p>}
+        <h1 className="text-4xl font-black tracking-tight text-white md:text-5xl">{title}</h1>
+        {subtitle && <p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-gray-400">{subtitle}</p>}
+      </div>
+    </GridHero>
+  );
+}
+```
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass.
+
+```bash
+git add src/components/ui/GridHero.tsx src/components/ui/PageHeader.tsx
+git commit -m "feat(ui): add GridHero and PageHeader hero components"
+```
+
+---
+
+## Task 4: Accordion (client)
+
+**Files:**
+- Create: `src/components/ui/Accordion.tsx`
+
+**Interfaces:**
+- Produces: `Accordion({ items }: { items: { q: string; a: React.ReactNode }[] })` — client component, one open at a time not required (each toggles independently), chevron rotates, accessible via `<button aria-expanded>`.
+
+- [ ] **Step 1: Create `src/components/ui/Accordion.tsx`**
+
+```tsx
+'use client';
+
+import React, { useState } from 'react';
+
+export type AccordionItemData = { q: string; a: React.ReactNode };
+
+export default function Accordion({ items }: { items: AccordionItemData[] }) {
+  const [open, setOpen] = useState<number | null>(null);
+  return (
+    <div className="divide-y divide-white/10 overflow-hidden rounded-xl border border-white/10">
+      {items.map((item, i) => {
+        const isOpen = open === i;
+        return (
+          <div key={i} className="bg-white/[0.02]">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+              aria-expanded={isOpen}
+              onClick={() => setOpen(isOpen ? null : i)}
+            >
+              <span className="font-medium text-white">{item.q}</span>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                className={`h-5 w-5 shrink-0 text-orange-400 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+              </svg>
+            </button>
+            {isOpen && <div className="px-5 pb-5 text-sm leading-relaxed text-gray-300">{item.a}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass.
+
+```bash
+git add src/components/ui/Accordion.tsx
+git commit -m "feat(ui): add accessible Accordion client component"
+```
+
+---
+
+## Task 5: Restyle Navigation + Footer, add Guide
+
+**Files:**
+- Modify: `src/components/Navigation.tsx`, `src/components/Footer.tsx`
+
+**Interfaces:**
+- Consumes: nothing new (uses Tailwind + tokens).
+- Produces: Guide entry in top nav and footer.
+
+- [ ] **Step 1: Add Guide to nav items and restyle active state in `src/components/Navigation.tsx`**
+
+Replace the `navItems` array (lines 7-16) with:
+
+```tsx
+const navItems = [
+  { href: '/',            label: 'Home' },
+  { href: '/downloads/',  label: 'Downloads' },
+  { href: '/guide/',      label: 'Guide' },
+  { href: '/features/',   label: 'Features' },
+  { href: '/about/',      label: 'About' },
+  { href: '/support/',    label: 'Support' },
+  { href: '/donate/',     label: 'Donate' },
+  { href: '/status/',     label: 'Status' },
+];
+```
+
+Update `linkClass` (lines 25-30) so the active state uses the gradient and hover is subtler:
+
+```tsx
+  const linkClass = (href: string) =>
+    `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+      isActive(href)
+        ? 'btn-gradient text-white'
+        : 'text-gray-300 hover:bg-white/5 hover:text-white'
+    }`;
+```
+
+Add a helper above `linkClass` so `/guide/` also highlights on `/guide/*` sub-pages (replace the single `normalizedPath ===` equality):
+
+```tsx
+  const isActive = (href: string) => {
+    if (href === '/') return normalizedPath === '/';
+    return normalizedPath === href || normalizedPath.startsWith(href);
+  };
+```
+
+Restyle the `<nav>` element (line 33) to a stronger glass treatment:
+
+```tsx
+    <nav aria-label="Main navigation" className="sticky top-0 z-50 border-b border-white/10 bg-ink/80 text-white backdrop-blur-md">
+```
+
+Update the mobile menu container (line 73) to match:
+
+```tsx
+        <div className="md:hidden border-t border-white/10 bg-ink/95 px-4 py-3 space-y-1">
+```
+
+- [ ] **Step 2: Add Guide to Footer in `src/components/Footer.tsx`**
+
+In the "App" column (lines 32-37), add a Guide link after Features:
+
+```tsx
+              <FooterLink href="/guide/">Guide</FooterLink>
+```
+
+In the "Support" column keep existing links; add the FAQ guide link after "FAQ &amp; Help":
+
+```tsx
+              <FooterLink href="/guide/faq/">Import FAQ</FooterLink>
+```
+
+Change the footer background (line 17) from `bg-gray-950` to `bg-ink`:
+
+```tsx
+    <footer className="border-t border-white/10 bg-ink mt-16">
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run type-check && npm run lint && npm run build`
+Expected: pass. Then `npm run dev`, confirm nav shows Guide, active state uses the gradient, `/guide/*` will highlight Guide.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Navigation.tsx src/components/Footer.tsx
+git commit -m "feat(nav): glassmorphism nav + footer, add Guide entry with sub-route highlighting"
+```
+
+---
+
+## Task 6: Guide shell (layout + nav data + index)
+
+**Files:**
+- Create: `src/app/guide/guideNav.ts`, `src/app/guide/layout.tsx`, `src/app/guide/page.tsx`
+
+**Interfaces:**
+- Consumes: `PageHeader`, `Section`, `FeatureCard`, `Card` (Tasks 2-3).
+- Produces: `GUIDE_PAGES` ordered array; guide layout with sub-nav + prev/next.
+
+- [ ] **Step 1: Create `src/app/guide/guideNav.ts`**
+
+```ts
+export type GuidePage = { href: string; label: string; blurb: string };
+
+export const GUIDE_PAGES: GuidePage[] = [
+  { href: '/guide/', label: 'Overview', blurb: 'Start here — get your first game running.' },
+  { href: '/guide/importing/', label: 'Importing Games', blurb: 'Files app, drag-and-drop, Wi-Fi upload, and URL scheme.' },
+  { href: '/guide/formats/', label: 'Supported Formats', blurb: 'Every extension iFly reads, and which to prefer.' },
+  { href: '/guide/bios/', label: 'BIOS Setup', blurb: 'When you need a BIOS and where it goes.' },
+  { href: '/guide/arcade/', label: 'Arcade & Naomi Rips', blurb: 'Naomi, Naomi 2, and Atomiswave in odd formats.' },
+  { href: '/guide/systems/', label: 'Systems', blurb: 'Every system iFly runs, with per-system notes.' },
+  { href: '/guide/faq/', label: 'FAQ & Troubleshooting', blurb: 'Fixes for the common failures.' },
+];
+```
+
+- [ ] **Step 2: Create `src/app/guide/layout.tsx`**
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { GUIDE_PAGES } from './guideNav';
+
+export default function GuideLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  const currentIndex = GUIDE_PAGES.findIndex((p) => p.href === normalized);
+  const prev = currentIndex > 0 ? GUIDE_PAGES[currentIndex - 1] : null;
+  const next = currentIndex >= 0 && currentIndex < GUIDE_PAGES.length - 1 ? GUIDE_PAGES[currentIndex + 1] : null;
+
+  return (
+    <div className="container mx-auto px-4 py-10">
+      <div className="grid gap-10 lg:grid-cols-[220px_1fr]">
+        {/* Sub-nav */}
+        <aside className="lg:sticky lg:top-24 lg:self-start">
+          <nav aria-label="Guide navigation" className="flex gap-2 overflow-x-auto lg:flex-col lg:gap-1">
+            {GUIDE_PAGES.map((p) => {
+              const active = p.href === normalized;
+              return (
+                <Link
+                  key={p.href}
+                  href={p.href}
+                  className={`whitespace-nowrap rounded-md px-3 py-2 text-sm transition-colors ${
+                    active ? 'bg-orange-500/15 font-medium text-orange-300' : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                  }`}
+                >
+                  {p.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+
+        {/* Content */}
+        <div className="min-w-0">
+          <article className="prose-guide max-w-none">{children}</article>
+
+          {(prev || next) && (
+            <div className="mt-12 flex items-center justify-between gap-4 border-t border-white/10 pt-6">
+              {prev ? (
+                <Link href={prev.href} className="text-sm text-gray-400 hover:text-orange-300">
+                  ← {prev.label}
+                </Link>
+              ) : <span />}
+              {next ? (
+                <Link href={next.href} className="text-sm text-gray-400 hover:text-orange-300">
+                  {next.label} →
+                </Link>
+              ) : <span />}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Note: this layout is a client component (uses `usePathname`) and does not export `metadata` — each page below exports its own. That is allowed: the layout has no metadata export.
+
+- [ ] **Step 3: Create `src/app/guide/page.tsx` (index)**
+
+```tsx
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { GUIDE_PAGES } from './guideNav';
+
+export const metadata: Metadata = {
+  title: 'Guide',
+  description: 'How to import games, which formats iFly supports, BIOS setup, arcade and Naomi rips, and troubleshooting.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/' },
+};
+
+export default function GuideIndex() {
+  const pages = GUIDE_PAGES.filter((p) => p.href !== '/guide/');
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">iFly Guide</h1>
+      <p className="mt-3 max-w-2xl text-gray-400">
+        Everything you need to get games running on iFly. New here? Most Dreamcast games need
+        no BIOS at all — drop a <code>.chd</code> or <code>.cdi</code> into iFly and go.
+      </p>
+
+      <div className="mt-8 rounded-xl border border-orange-500/20 bg-orange-500/[0.06] p-5">
+        <h2 className="text-lg font-semibold text-white">First import in 3 steps</h2>
+        <ol className="mt-3 list-decimal space-y-1 pl-5 text-sm text-gray-300">
+          <li>Get a Dreamcast game as <code>.chd</code>, <code>.cdi</code>, or <code>.gdi</code>.</li>
+          <li>Open iFly → import via the Files app, drag-and-drop, or Wi-Fi upload.</li>
+          <li>Tap the game. No BIOS required for Dreamcast.</li>
+        </ol>
+      </div>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {pages.map((p) => (
+          <Link key={p.href} href={p.href} className="card-glass block p-5">
+            <h3 className="font-semibold text-white">{p.label}</h3>
+            <p className="mt-1 text-sm text-gray-400">{p.blurb}</p>
+          </Link>
+        ))}
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run type-check && npm run build`
+Expected: pass; `out/guide/index.html` generated. `npm run dev` → `/guide/` shows sub-nav + cards.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/guide/guideNav.ts src/app/guide/layout.tsx src/app/guide/page.tsx
+git commit -m "feat(guide): add guide shell, sub-nav data, and overview page"
+```
+
+---
+
+## Task 7: Guide — Importing Games
+
+**Files:**
+- Create: `src/app/guide/importing/page.tsx`
+
+**Interfaces:**
+- Consumes: `Callout`, `Screenshot`.
+
+- [ ] **Step 1: Create `src/app/guide/importing/page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+import Screenshot from '@/components/ui/Screenshot';
+
+export const metadata: Metadata = {
+  title: 'Importing Games',
+  description: 'Import Dreamcast and arcade games into iFly via the Files app, drag-and-drop, Wi-Fi upload, or the ifly:// URL scheme.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/importing/' },
+};
+
+export default function ImportingPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Importing Games</h1>
+      <p className="mt-3 text-gray-400">
+        iFly imports games four ways. All of them route through the same importer, so the file
+        ends up in the right place no matter which you use.
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold text-white">Files app / document picker</h2>
+      <p className="mt-2 text-gray-400">
+        In iFly, add games from the Files app. Pick a single file (<code>.chd</code>,
+        <code>.cdi</code>, <code>.gdi</code>) or a whole folder for multi-track dumps. This works
+        on iOS, iPadOS, and tvOS.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Drag-and-drop (iPad)</h2>
+      <p className="mt-2 text-gray-400">
+        On iPad (iOS 15+), drag files from Files, Safari downloads, or another app straight onto
+        the iFly library grid.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Wi-Fi upload (WebDAV / HTTP)</h2>
+      <p className="mt-2 text-gray-400">
+        Start the built-in web server in iFly, then scan the QR code or open the shown URL in a
+        desktop browser and drag files in. Works over WebDAV or plain HTTP on iOS, tvOS, and
+        macOS — the easiest way to move large arcade sets onto Apple TV.
+      </p>
+      <Screenshot alt="Wi-Fi upload screen with QR code" width={1200} height={800} className="mt-4" />
+
+      <h2 className="mt-8 text-xl font-semibold text-white">URL scheme</h2>
+      <p className="mt-2 text-gray-400">
+        Links using the <code>ifly://</code> scheme open a file and import it through the same
+        policy.
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold text-white">Where files go</h2>
+      <p className="mt-2 text-gray-400">
+        Games land in <code>ROMs/</code>, BIOS in <code>BIOS/</code>, controller skins in
+        <code>Skins/</code> (under Documents or Caches). Skins (<code>.deltaskin</code>,
+        <code>.manicskin</code>) are routed to <code>Skins/</code> automatically.
+      </p>
+
+      <Callout variant="info" title="What happens to archives">
+        Disc archives (a <code>.zip</code> or <code>.7z</code> containing a <code>.gdi</code> or
+        <code>.cue</code>) are extracted on import. Arcade romsets are copied as-is so the MAME
+        loader can open them in place. Extraction is all-or-nothing: a partial extract rolls back
+        and leaves the source archive alone.
+      </Callout>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass; `out/guide/importing/index.html` exists.
+
+```bash
+git add src/app/guide/importing/page.tsx
+git commit -m "feat(guide): add Importing Games page"
+```
+
+---
+
+## Task 8: Guide — Supported Formats
+
+**Files:**
+- Create: `src/app/guide/formats/page.tsx`
+
+**Interfaces:**
+- Consumes: `Callout`.
+
+- [ ] **Step 1: Create `src/app/guide/formats/page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+
+export const metadata: Metadata = {
+  title: 'Supported Formats',
+  description: 'Every disc image, track, archive, and skin format iFly supports, and why to prefer CHD or CDI over GDI.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/formats/' },
+};
+
+const rows: [string, string, string][] = [
+  ['.chd', 'Standalone disc', 'Compressed, single file. Best storage (~700 MB → ~300 MB). Dreamcast + Naomi GD-ROM.'],
+  ['.cdi', 'Standalone disc', 'Single-file Dreamcast image. No tracks to lose.'],
+  ['.iso', 'Standalone disc', 'Single-file image.'],
+  ['.gdi', 'Index', 'GD-ROM index that points at .bin / .raw / .img tracks. All tracks must be present.'],
+  ['.cue', 'Index', 'CUE sheet that points at .bin tracks.'],
+  ['.bin / .raw / .img', 'Track', 'Payload tracks referenced by a .gdi or .cue.'],
+  ['.dat', 'Arcade payload', 'Decrypted single-cart arcade ROM (often inside a .zip).'],
+  ['.lst', 'Arcade list', 'Metadata for MAME-style arcade rips.'],
+  ['.m3u', 'Playlist', 'Groups multiple discs into an ordered multi-disc set.'],
+  ['.elf', 'Homebrew', 'Raw homebrew executable.'],
+  ['.zip / .7z', 'Archive', 'Disc archives are extracted; arcade romsets copied as-is.'],
+  ['.deltaskin / .manicskin / .skin / .emuskin', 'Controller skin', 'Routed to the Skins folder.'],
+];
+
+export default function FormatsPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Supported Formats</h1>
+      <p className="mt-3 text-gray-400">
+        iFly reads the same disc and arcade formats as Flycast, plus extra handling for odd
+        arcade rips (see <a href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</a>).
+      </p>
+
+      <Callout variant="tip" title="Prefer CHD or CDI over GDI">
+        A <code>.chd</code> or <code>.cdi</code> is a single file — nothing to lose. A
+        <code>.gdi</code> references separate <code>.bin</code>/<code>.raw</code> tracks, and the
+        game will not boot if any track is missing. <code>.chd</code> is also compressed, roughly
+        halving disk use.
+      </Callout>
+
+      <div className="mt-8 overflow-x-auto rounded-xl border border-white/10">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.03] text-gray-300">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Extension</th>
+              <th className="px-4 py-3 font-semibold">Kind</th>
+              <th className="px-4 py-3 font-semibold">Notes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5 text-gray-400">
+            {rows.map(([ext, kind, notes]) => (
+              <tr key={ext} className="align-top">
+                <td className="px-4 py-3"><code className="text-orange-300">{ext}</code></td>
+                <td className="px-4 py-3 whitespace-nowrap">{kind}</td>
+                <td className="px-4 py-3">{notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass.
+
+```bash
+git add src/app/guide/formats/page.tsx
+git commit -m "feat(guide): add Supported Formats page with format table"
+```
+
+---
+
+## Task 9: Guide — BIOS Setup
+
+**Files:**
+- Create: `src/app/guide/bios/page.tsx`
+
+**Interfaces:**
+- Consumes: `Callout`, `Badge` (from `Badge.tsx`).
+
+- [ ] **Step 1: Create `src/app/guide/bios/page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+import { Badge } from '@/components/ui/Badge';
+
+export const metadata: Metadata = {
+  title: 'BIOS Setup',
+  description: 'Dreamcast needs no BIOS in iFly. Only the arcade systems require one — here are the exact files and where they go.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/bios/' },
+};
+
+const biosRows: { system: string; file: string; required: boolean; notes: string }[] = [
+  { system: 'Dreamcast', file: 'dc_boot.bin', required: false, notes: 'Boot animation only. HLE BIOS (Reios) is used by default.' },
+  { system: 'Dreamcast', file: 'dc_flash.bin', required: false, notes: 'Flash / NVRAM (clock, settings). Pair with dc_boot.bin for full accuracy.' },
+  { system: 'Naomi', file: 'naomi.zip', required: true, notes: 'MAME romset. Basename must match exactly.' },
+  { system: 'Naomi 2', file: 'naomi2.zip', required: true, notes: 'MAME romset.' },
+  { system: 'Atomiswave', file: 'awbios.zip', required: true, notes: 'MAME romset.' },
+  { system: 'System SP', file: 'segasp.zip', required: true, notes: 'MAME romset.' },
+  { system: 'House of the Dead 2', file: 'hod2bios.zip', required: false, notes: 'Game-specific board.' },
+  { system: 'Ferrari F355', file: 'f355bios.zip / f355dlx.zip', required: false, notes: 'Challenge / Deluxe variants.' },
+  { system: 'Airline Pilots', file: 'airlbios.zip', required: false, notes: 'Also covers Sega Strike Fighter.' },
+];
+
+export default function BiosPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">BIOS Setup</h1>
+
+      <Callout variant="tip" title="Dreamcast needs no BIOS">
+        Almost every Dreamcast game runs on iFly&apos;s built-in HLE BIOS (Reios). You only need
+        a real BIOS for the arcade systems (Naomi, Naomi 2, Atomiswave, System SP).
+      </Callout>
+
+      <p className="mt-6 text-gray-400">
+        Put BIOS files in the <code>BIOS/</code> folder. Names are case-normalized to lowercase,
+        and MAME romsets must keep their exact basename.
+      </p>
+
+      <div className="mt-8 overflow-x-auto rounded-xl border border-white/10">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.03] text-gray-300">
+            <tr>
+              <th className="px-4 py-3 font-semibold">System</th>
+              <th className="px-4 py-3 font-semibold">File</th>
+              <th className="px-4 py-3 font-semibold">Required</th>
+              <th className="px-4 py-3 font-semibold">Notes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5 text-gray-400">
+            {biosRows.map((r) => (
+              <tr key={`${r.system}-${r.file}`} className="align-top">
+                <td className="px-4 py-3 whitespace-nowrap">{r.system}</td>
+                <td className="px-4 py-3"><code className="text-orange-300">{r.file}</code></td>
+                <td className="px-4 py-3">
+                  <Badge tone={r.required ? 'required' : 'optional'}>{r.required ? 'Required' : 'Optional'}</Badge>
+                </td>
+                <td className="px-4 py-3">{r.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass.
+
+```bash
+git add src/app/guide/bios/page.tsx
+git commit -m "feat(guide): add BIOS Setup page with requirement matrix"
+```
+
+---
+
+## Task 10: Guide — Arcade & Naomi Rips
+
+**Files:**
+- Create: `src/app/guide/arcade/page.tsx`
+
+**Interfaces:**
+- Consumes: `Callout`.
+
+- [ ] **Step 1: Create `src/app/guide/arcade/page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+
+export const metadata: Metadata = {
+  title: 'Arcade & Naomi Rips',
+  description: 'How iFly handles Naomi, Naomi 2, and Atomiswave rips in odd formats — decrypted single-cart bins, multi-track GD-ROM dumps, and GD-cartridge zip+CHD layouts.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/arcade/' },
+};
+
+export default function ArcadePage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Arcade &amp; Naomi Rips</h1>
+      <p className="mt-3 text-gray-400">
+        Naomi, Naomi 2, and Atomiswave rips arrive in several shapes. iFly detects each and
+        routes it correctly — including formats stock Flycast can&apos;t open. You still need the
+        matching arcade BIOS (see <a href="/guide/bios/" className="text-orange-300 hover:underline">BIOS Setup</a>).
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold text-white">Decrypted single-cart ROMs</h2>
+      <p className="mt-2 text-gray-400">
+        Many archive.org rips are a single decrypted <code>.bin</code> named after the game, e.g.
+        <code>VirtuaFighter4.zip</code> containing <code>VirtuaFighter4.bin</code> with no
+        <code>.ic*</code> chip files. iFly detects the single-cart shape, routes it to the
+        decrypted-ROM path, and Flycast peeks the board header (<code>NAOMI</code> /
+        <code>Naomi2</code>) to auto-select the BIOS. Stock Flycast sends these to its MAME loader
+        and fails.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Multi-track GD-ROM dumps</h2>
+      <p className="mt-2 text-gray-400">
+        Arcade GD-ROM games sometimes come as a <code>.cue</code> plus several <code>.bin</code>
+        tracks (e.g. Slashout). iFly treats the <code>.cue</code> as a disc, extracts it like a
+        Dreamcast multi-track set, and verifies every referenced track exists.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Naomi GD-cartridge (zip + CHD)</h2>
+      <p className="mt-2 text-gray-400">
+        Some Naomi games pair a MAME cart zip with a GD-ROM image in a subfolder:
+        <code>senkosp.zip</code> alongside <code>senkosp/gdl-0030a.chd</code>. iFly carries the
+        sibling CHD with the cart zip on import and warns if the CHD is missing before boot.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">MAME chip-set zips</h2>
+      <p className="mt-2 text-gray-400">
+        Traditional MAME romsets (a <code>.zip</code> of <code>.ic*</code> chip files) are copied
+        as-is and opened directly by the MAME loader.
+      </p>
+
+      <Callout variant="warn" title="If an arcade game won't boot">
+        Check that the arcade BIOS (<code>naomi.zip</code>, <code>naomi2.zip</code>,
+        <code>awbios.zip</code>, or <code>segasp.zip</code>) is in <code>BIOS/</code>, and that a
+        GD-cartridge game&apos;s companion <code>.chd</code> sits in its named subfolder.
+      </Callout>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass.
+
+```bash
+git add src/app/guide/arcade/page.tsx
+git commit -m "feat(guide): add Arcade & Naomi Rips page"
+```
+
+---
+
+## Task 11: Guide — Systems
+
+**Files:**
+- Create: `src/app/guide/systems/page.tsx`
+
+**Interfaces:**
+- Consumes: `Badge`.
+
+- [ ] **Step 1: Create `src/app/guide/systems/page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import { Badge } from '@/components/ui/Badge';
+
+export const metadata: Metadata = {
+  title: 'Systems',
+  description: 'Every system iFly runs: Dreamcast, Naomi, Naomi 2, Atomiswave, System SP, and game-specific boards.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/systems/' },
+};
+
+const systems: { name: string; biosRequired: boolean; notes: string }[] = [
+  { name: 'Dreamcast', biosRequired: false, notes: 'Consumer console. Runs on the built-in HLE BIOS; no BIOS file needed.' },
+  { name: 'Naomi', biosRequired: true, notes: 'Arcade board. Requires naomi.zip.' },
+  { name: 'Naomi 2', biosRequired: true, notes: 'Upgraded arcade board. Requires naomi2.zip.' },
+  { name: 'Atomiswave', biosRequired: true, notes: 'Sammy arcade hardware. Requires awbios.zip.' },
+  { name: 'System SP ("Spider")', biosRequired: true, notes: 'Sega arcade system. Requires segasp.zip.' },
+  { name: 'Game-specific boards', biosRequired: false, notes: 'House of the Dead 2, Ferrari F355, Airline Pilots — optional per-game BIOS.' },
+];
+
+export default function SystemsPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Systems</h1>
+      <p className="mt-3 text-gray-400">
+        iFly runs the Sega Dreamcast plus the arcade platforms it shares hardware with. Arcade
+        systems need a BIOS; Dreamcast does not.
+      </p>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {systems.map((s) => (
+          <div key={s.name} className="card-glass p-5">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="font-semibold text-white">{s.name}</h2>
+              <Badge tone={s.biosRequired ? 'required' : 'optional'}>
+                {s.biosRequired ? 'BIOS required' : 'No BIOS'}
+              </Badge>
+            </div>
+            <p className="mt-2 text-sm text-gray-400">{s.notes}</p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass.
+
+```bash
+git add src/app/guide/systems/page.tsx
+git commit -m "feat(guide): add Systems page"
+```
+
+---
+
+## Task 12: Guide — FAQ & Troubleshooting
+
+**Files:**
+- Create: `src/app/guide/faq/FaqAccordion.tsx`, `src/app/guide/faq/page.tsx`
+
+**Interfaces:**
+- Consumes: `Accordion` (Task 4).
+
+- [ ] **Step 1: Create `src/app/guide/faq/FaqAccordion.tsx`**
+
+```tsx
+'use client';
+
+import Accordion, { type AccordionItemData } from '@/components/ui/Accordion';
+
+const items: AccordionItemData[] = [
+  {
+    q: 'My game won’t boot. What’s wrong?',
+    a: (
+      <>
+        For arcade games, confirm the arcade BIOS (<code>naomi.zip</code>, <code>naomi2.zip</code>,
+        <code>awbios.zip</code>, <code>segasp.zip</code>) is in <code>BIOS/</code>. For a
+        <code>.gdi</code> or <code>.cue</code>, confirm every referenced track
+        (<code>.bin</code>/<code>.raw</code>/<code>.img</code>) is present. Prefer a single-file
+        <code>.chd</code> or <code>.cdi</code> to avoid missing-track problems.
+      </>
+    ),
+  },
+  {
+    q: 'An arcade rip fails to import or load.',
+    a: (
+      <>
+        Arcade rips come in several shapes. See{' '}
+        <a href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</a>{' '}
+        for decrypted single-cart <code>.bin</code> dumps, multi-track GD-ROM dumps, and Naomi
+        GD-cartridge <code>zip</code>+<code>.chd</code> layouts.
+      </>
+    ),
+  },
+  {
+    q: 'How do I add a multi-disc game?',
+    a: (
+      <>
+        Import each disc, then use an <code>.m3u</code> playlist listing the disc images in order.
+        iFly groups them as one multi-disc game.
+      </>
+    ),
+  },
+  {
+    q: 'What syncs over iCloud?',
+    a: (
+      <>
+        Saves, VMUs, and BIOS sync across your devices over iCloud. ROMs do not sync — import
+        those on each device.
+      </>
+    ),
+  },
+  {
+    q: 'Do auto-saves interrupt gameplay?',
+    a: (
+      <>
+        No. iFly serializes save states off the main thread, so timed auto-saves run without
+        stalling emulation.
+      </>
+    ),
+  },
+  {
+    q: 'How do I set up controllers?',
+    a: (
+      <>
+        See the <a href="/controllers/" className="text-orange-300 hover:underline">Controllers</a>{' '}
+        page for MFi, DualShock, DualSense, Xbox, and Switch mappings, plus on-screen control
+        options.
+      </>
+    ),
+  },
+  {
+    q: 'How do I get better performance or higher resolution?',
+    a: (
+      <>
+        iFly runs JIT-less at full speed on Apple silicon and can upscale to <code>1440p</code> or
+        <code>4K</code> on recent devices. Use per-game options to tune internal resolution,
+        frame pacing, and ProMotion refresh.
+      </>
+    ),
+  },
+];
+
+export default function FaqAccordion() {
+  return <Accordion items={items} />;
+}
+```
+
+- [ ] **Step 2: Create `src/app/guide/faq/page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import FaqAccordion from './FaqAccordion';
+
+export const metadata: Metadata = {
+  title: 'FAQ & Troubleshooting',
+  description: 'Fixes for the common iFly problems: games that won’t boot, arcade rip failures, multi-disc games, iCloud sync, and performance.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/faq/' },
+};
+
+export default function FaqPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">FAQ &amp; Troubleshooting</h1>
+      <p className="mt-3 mb-8 text-gray-400">
+        The common failures and how to fix them. Still stuck? Ask in the{' '}
+        <a href="https://discord.gg/QF5ZjVT4Sa" target="_blank" rel="noopener noreferrer" className="text-orange-300 hover:underline">Discord</a>.
+      </p>
+      <FaqAccordion />
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `npm run type-check && npm run build`
+Expected: pass; FAQ accordion opens/closes in `npm run dev`.
+
+```bash
+git add src/app/guide/faq/FaqAccordion.tsx src/app/guide/faq/page.tsx
+git commit -m "feat(guide): add FAQ & Troubleshooting page with accordion"
+```
+
+---
+
+## Task 13: Rewrite Features with the grouped feature set
+
+**Files:**
+- Modify: `src/components/Features.tsx`
+
+**Interfaces:**
+- Consumes: `FeatureCard` (Task 2) — replaces the inline card markup.
+- Produces: `Features({ compact?, className? })` unchanged signature (homepage uses `compact`), but now renders grouped sections when `compact` is false.
+
+- [ ] **Step 1: Rewrite `src/components/Features.tsx`**
+
+Keep the existing icon components (`ControllerIcon`, `PhoneIcon`, etc.) — reuse them. Replace `allFeatures`/`extendedOnly`/render with grouped data + `FeatureCard`. Full file:
+
+```tsx
+import React from 'react';
+import { FeatureCard } from '@/components/ui/Card';
+
+// Reuse a compact inline icon set (24x24, currentColor).
+const Icon = ({ d }: { d: string }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6" aria-hidden="true"><path d={d} /></svg>
+);
+
+const ICONS = {
+  bolt: 'M13 2 4 14h6l-1 8 9-12h-6l1-8Z',
+  cpu: 'M9 3h6v2h3a2 2 0 0 1 2 2v3h2v2h-2v3a2 2 0 0 1-2 2h-3v2H9v-2H6a2 2 0 0 1-2-2v-3H2v-2h2V7a2 2 0 0 1 2-2h3V3Zm-1 6v6h8V9H8Z',
+  sparkles: 'M11 2 9 7l-5 2 5 2 2 5 2-5 5-2-5-2-2-5Zm8 9-1 3-3 1 3 1 1 3 1-3 3-1-3-1-1-3Z',
+  save: 'M5 3h11l3 3v15a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm2 4v4h8V7H7Zm8 12v-5H9v5h6Z',
+  cloud: 'M7 18h9a4 4 0 1 0-1.1-7.9A5 5 0 0 0 5 12a4 4 0 0 0 2 6Z',
+  controller: 'M6 8h12a4 4 0 0 1 3.8 5.2l-1.1 3A3 3 0 0 1 17 18h-2l-2-2h-2l-2 2H7a3 3 0 0 1-3.7-1.8l-1.1-3A4 4 0 0 1 6 8Zm2 2v2H6v2h2v2h2v-2h2v-2h-2v-2H8Zm8 .5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z',
+  target: 'M12 2v2a8 8 0 1 1-8 8H2a10 10 0 1 0 10-10Zm0 6a4 4 0 1 0 4 4h2a6 6 0 1 1-6-6v2Z',
+  phone: 'M7 2h10a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Zm5 18a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z',
+  chart: 'M4 20V4h2v16H4Zm4 0v-9h2v9H8Zm4 0v-6h2v6h-2Zm4 0v-12h2v12h-2Z',
+  search: 'M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm8.7 13.3 3.3 3.3-1.4 1.4-3.3-3.3 1.4-1.4Z',
+  network: 'M12 2a4 4 0 0 1 1 7.87V11h6a1 1 0 0 1 1 1v2.13a4 4 0 1 1-2 0V13h-5v1.13a4 4 0 1 1-2 0V13H6v1.13a4 4 0 1 1-2 0V12a1 1 0 0 1 1-1h6V9.87A4 4 0 0 1 12 2Z',
+} as const;
+
+type Feature = { title: string; description: string; icon: React.ReactNode };
+type Group = { heading: string; items: Feature[] };
+
+const f = (title: string, description: string, d: string): Feature => ({ title, description, icon: <Icon d={d} /> });
+
+const GROUPS: Group[] = [
+  {
+    heading: 'Performance & graphics',
+    items: [
+      f('JIT-less full speed', 'Custom Apple-silicon CPU work runs Dreamcast at full speed with no JIT. Upscales to 1440p or 4K on recent devices.', ICONS.cpu),
+      f('Custom Metal backend', 'A Metal renderer built for Apple GPUs, with HDR upscaling support.', ICONS.sparkles),
+      f('1K+ Metal shaders', 'A large native shader library for visual quality and effects.', ICONS.bolt),
+      f('Texture packs', 'Custom texture-pack support with a management UI, like Flycast.', ICONS.chart),
+      f('ProMotion support', 'High-refresh ProMotion rendering, or lock to the original refresh rate.', ICONS.phone),
+    ],
+  },
+  {
+    heading: 'VMU tooling',
+    items: [
+      f('Floating VMU window', 'Keep a live VMU on screen while you play.', ICONS.save),
+      f('VMU Watch companion', 'A live VMU viewer on Apple Watch.', ICONS.save),
+      f('Native VMU file manager', 'A Swift-native VMU manager with per-game and per-VMU backup and restore.', ICONS.save),
+    ],
+  },
+  {
+    heading: 'Saves & sync',
+    items: [
+      f('iCloud sync', 'Saves, VMUs, and BIOS sync across devices over iCloud. ROMs stay local.', ICONS.cloud),
+      f('Off-thread auto-saves', 'Timed auto-saves serialize off the main thread, so emulation never stalls.', ICONS.save),
+      f('HLE & native BIOS', 'Run on the built-in HLE BIOS, or supply a real BIOS.', ICONS.cpu),
+    ],
+  },
+  {
+    heading: 'Input & controls',
+    items: [
+      f('External controllers + haptics', 'DualShock, DualSense, Xbox, Switch, and MFi controllers, with haptics.', ICONS.controller),
+      f('Jump Pack rumble', 'Jump Pack rumble maps to device haptics or controller rumble.', ICONS.controller),
+      f('Remappable + presets', 'Remap external controller buttons and save presets.', ICONS.target),
+      f('On-screen controls', 'Customizable, movable on-screen controls.', ICONS.target),
+      f('Keyboard & mouse', 'On-screen touch keyboard/mouse plus native Bluetooth keyboard, mouse, and Smart Keyboard where the OS supports it.', ICONS.phone),
+      f('Light gun & microphone', 'Touch light-gun input and native CoreAudio microphone input.', ICONS.target),
+      f('DeltaSkin / ManicSkin', 'Import DeltaSkin and ManicSkin controller skins.', ICONS.controller),
+    ],
+  },
+  {
+    heading: 'Connectivity & display',
+    items: [
+      f('External display', 'Output to an external display on iOS and iPadOS.', ICONS.phone),
+      f('DCNet & LAN', 'DCNet network and LAN support, matching Flycast.', ICONS.network),
+    ],
+  },
+  {
+    heading: 'Games & content',
+    items: [
+      f('Cheat database', 'In-app cheat-code database.', ICONS.sparkles),
+      f('RetroAchievements', 'RetroAchievements support.', ICONS.target),
+      f('Metadata lookup', 'Online game-metadata lookup for your library.', ICONS.search),
+      f('Per-game options', 'Tune options per game.', ICONS.chart),
+    ],
+  },
+  {
+    heading: 'Platform & import',
+    items: [
+      f('iOS, iPadOS, tvOS', 'One app across iPhone, iPad, and Apple TV.', ICONS.phone),
+      f('Recent-games widget', 'Quick-launch recent games from a Springboard widget.', ICONS.bolt),
+      f('Flexible import', 'WebDAV, HTTP, or Files.app import, plus drag-and-drop on iPad.', ICONS.cloud),
+    ],
+  },
+];
+
+// Curated highlights for the homepage compact view.
+const HIGHLIGHTS: Feature[] = [
+  GROUPS[0].items[0], // JIT-less full speed
+  GROUPS[0].items[2], // 1K+ Metal shaders
+  GROUPS[1].items[0], // Floating VMU window
+  GROUPS[2].items[0], // iCloud sync
+  GROUPS[3].items[0], // External controllers + haptics
+  GROUPS[5].items[1], // RetroAchievements
+];
+
+export type FeaturesProps = { compact?: boolean; className?: string };
+
+export default function Features({ compact = false, className }: FeaturesProps) {
+  if (compact) {
+    return (
+      <div className={className}>
+        <div className="grid gap-5 md:grid-cols-3">
+          {HIGHLIGHTS.map((item) => (
+            <FeatureCard key={item.title} icon={item.icon} title={item.title}>{item.description}</FeatureCard>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <div className="space-y-12">
+        {GROUPS.map((group) => (
+          <div key={group.heading}>
+            <h3 className="mb-5 text-sm font-semibold uppercase tracking-wide text-orange-400">{group.heading}</h3>
+            <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+              {group.items.map((item) => (
+                <FeatureCard key={item.title} icon={item.icon} title={item.title}>{item.description}</FeatureCard>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run type-check && npm run lint && npm run build`
+Expected: pass. Homepage still calls `<Features compact />`; `/features` calls `<Features />`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Features.tsx
+git commit -m "feat(features): grouped feature set with homepage highlights"
+```
+
+---
+
+## Task 14: Restyle homepage
+
+**Files:**
+- Modify: `src/app/page.tsx`
+
+**Interfaces:**
+- Consumes: `GridHero`, `Section`, `GradientButton`, `Card`, `Screenshot`.
+
+- [ ] **Step 1: Convert the hero to `GridHero` + `.text-gradient` + `GradientButton`**
+
+In `src/app/page.tsx`, replace the hero `<section>` (lines 32-93) with a `GridHero`-based hero. Keep the app icon, badges, and the two CTAs, but:
+- Wrap in `<GridHero className="pt-20 pb-16 text-center">` and drop the now-duplicated manual radial-glow/overflow markup (GridHero provides it).
+- Change the `<h1>` orange span to gradient text: replace `<span className="text-orange-500">Fly</span>` with `<span className="text-gradient">Fly</span>`.
+- Replace both CTA `<Link>`s with `<GradientButton href="/testflight/">TestFlight Beta</GradientButton>` (solid) and `<GradientButton href="/downloads/" variant="outline">Download IPA</GradientButton>`.
+
+Add the imports at the top:
+
+```tsx
+import GridHero from '@/components/ui/GridHero';
+import Section from '@/components/ui/Section';
+import GradientButton from '@/components/ui/GradientButton';
+```
+
+- [ ] **Step 2: Restyle the stats, community, and screenshots sections to glass cards**
+
+- In the stats row (lines 96-110), change each stat card class from `bg-gray-900 border border-gray-800 rounded-xl` to `card-glass` (keep padding utilities).
+- In the Community + Donate section (lines 116-135), change both card wrappers from `bg-gray-900 border border-gray-800 rounded-2xl p-6` to `card-glass p-6`.
+- In the Features section wrapper (line 202), change `border-t border-gray-800/60` to `border-t border-white/10`.
+- Optionally wrap the screenshot device sections' container in `<Section tone="ink-2">` for alternating background. Leave `DeviceFrame` usage intact.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run type-check && npm run lint && npm run build`
+Expected: pass. `npm run dev` → hero shows animated grid + gradient "Fly", gradient CTA, glass cards.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/page.tsx
+git commit -m "feat(home): restyle homepage onto GridHero, gradient CTAs, and glass cards"
+```
+
+---
+
+## Task 15: Restyle remaining pages
+
+**Files:**
+- Modify: `src/app/features/page.tsx`, `src/app/about/page.tsx`, `src/app/support/page.tsx`, `src/app/downloads/page.tsx`, `src/app/links/page.tsx`, `src/app/donate/page.tsx`, `src/app/controllers/page.tsx`, `src/app/privacy/page.tsx`, `src/app/licenses/page.tsx`, `src/app/testflight/page.tsx`, `src/app/testflight-patrons/page.tsx`, `src/app/status/page.tsx`
+
+**Interfaces:**
+- Consumes: `PageHeader`, `Section`, `Card`, `Callout`, `GradientButton`.
+
+This is a repetitive restyle. Apply the same three substitutions to each page, then verify once at the end.
+
+- [ ] **Step 1: For each page, add a `PageHeader` and swap card/background classes**
+
+For every page listed above:
+1. If the page has a title heading block at the top, replace it with:
+   ```tsx
+   <PageHeader title="<Existing Title>" subtitle="<existing subtitle if any>" />
+   ```
+   and import `PageHeader from '@/components/ui/PageHeader'`. (Do not add a PageHeader to `status` if it would clash with the dashboard header — instead just swap classes there.)
+2. Replace card wrappers `bg-gray-900 border border-gray-800 rounded-2xl` (and `rounded-xl` variants) with `card-glass`.
+3. Replace section dividers `border-gray-800` → `border-white/10`, and any page-level `bg-gray-950` → `bg-ink`.
+4. Replace primary CTA links styled as orange buttons with `<GradientButton>`; leave secondary/outline links as-is or use `variant="outline"`.
+
+Work through them in this order, committing after each for reviewability: `about`, `features`, `support`, `downloads`, `links`, `donate`, `controllers`, `privacy`, `licenses`, `testflight`, `testflight-patrons`, `status`.
+
+- [ ] **Step 2: Verify after each page**
+
+Run: `npm run type-check && npm run build`
+Expected: pass. Spot-check the page in `npm run dev`.
+
+- [ ] **Step 3: Commit (per page or in small batches)**
+
+```bash
+git add src/app/<page>/page.tsx
+git commit -m "feat(pages): restyle <page> onto new design system"
+```
+
+---
+
+## Task 16: Sitemap + final verification
+
+**Files:**
+- Modify: `src/app/sitemap.ts`
+
+**Interfaces:**
+- Consumes: guide routes from Tasks 6-12.
+
+- [ ] **Step 1: Add guide routes to `src/app/sitemap.ts`**
+
+Insert after the `/downloads/` entry (line 9):
+
+```ts
+    { url: `${base}/guide/`,           changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${base}/guide/importing/`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/formats/`,   changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/bios/`,      changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/arcade/`,    changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/systems/`,   changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${base}/guide/faq/`,       changeFrequency: 'monthly', priority: 0.6 },
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `npm run type-check && npm run lint && npm run build`
+Expected: all pass; static export completes.
+
+Confirm generated output:
+```bash
+ls out/guide out/guide/importing out/guide/formats out/guide/bios out/guide/arcade out/guide/systems out/guide/faq
+grep -c "guide/" out/sitemap.xml
+```
+Expected: each guide directory contains `index.html`; `grep` count ≥ 7.
+
+- [ ] **Step 3: Manual pass in `npm run dev`**
+
+- Nav: Guide entry present; visiting any `/guide/*` highlights Guide.
+- Guide sub-nav highlights the current page; prev/next links work.
+- FAQ accordion opens/closes; chevron rotates.
+- Screenshot placeholders render with dimensions + captions.
+- Reduced-motion: with "Reduce Motion" on, the grid overlay is static.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/sitemap.ts
+git commit -m "feat(seo): add guide routes to sitemap"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Design tokens / retrowave patterns → Task 1. ✅
+- Reusable components (GridHero, PageHeader, Section, Card/FeatureCard, GradientButton, Accordion, Callout, Badge/Pill, Screenshot) → Tasks 2-4. ✅
+- Glassmorphism nav + Guide entry → Task 5. ✅
+- `/guide` multi-page section (importing, formats, BIOS, arcade, systems, FAQ) → Tasks 6-12. ✅
+- FAQ accordion → Tasks 4 + 12. ✅
+- Systems/compatibility page → Task 11. ✅
+- Feature set (all groups incl. VMU tooling, JIT-less 4K, off-thread saves) → Task 13. ✅
+- Homepage restyle + highlights → Task 14. ✅
+- Restyle all existing pages → Task 15. ✅
+- Sitemap + canonical metadata → Task 16 + each page. ✅
+- Screenshot placeholders → Task 2 (`Screenshot`) used in Tasks 7, 14, and available site-wide. ✅
+- VOICE.md copy rules → Global Constraints; applied in all content tasks. ✅
+- Deferred (no task, by design): dark/light toggle, blog, press kit, comparison tables. ✅
+
+**Placeholder scan:** No TBD/TODO. Task 15 is intentionally pattern-based (repetitive mechanical restyle across 12 near-identical pages) rather than full per-file code — each substitution is concrete and the components it uses are fully defined in Tasks 2-4.
+
+**Type consistency:** Component signatures in Tasks 2-4 match their consumers in Tasks 6-14 (`FeatureCard` icon+title+children; `Callout` variant/title; `Badge` tone `required|optional`; `Accordion` `items: {q,a}[]`; `Screenshot` width/height required; `GradientButton` variant `solid|outline`). `Features` keeps its `{ compact?, className? }` signature so existing call sites in `page.tsx` and `features/page.tsx` still compile.

--- a/docs/superpowers/specs/2026-07-02-ifly-site-redesign-guide-design.md
+++ b/docs/superpowers/specs/2026-07-02-ifly-site-redesign-guide-design.md
@@ -1,0 +1,258 @@
+# iFly Website Redesign + Guide — Design
+
+**Date:** 2026-07-02
+**Status:** Approved (design), pending implementation plan
+**Author:** Joe Mattiello (with Claude)
+
+## Goal
+
+Prepare the iFly marketing site for its first App Store release. Two tracks:
+
+1. **Content** — a new multi-page `/guide` section covering how to import games, what
+   formats are supported, BIOS setup, arcade/Naomi rip handling, systems/compatibility,
+   and a troubleshooting FAQ. This is the highest priority.
+2. **Restyle** — port the visual language of the recently-redesigned
+   `provenance-emu.com` (Hugo site) into the iFly Next.js site, keeping iFly's orange
+   brand. Build a small design-system layer so all existing pages and the new guide share
+   one look.
+
+## Non-goals (deferred)
+
+- Dark/light theme toggle (site stays dark-only for now).
+- Blog / news section, press kit, subscription/comparison tables.
+- No stack change. Provenance-emu is Hugo; we port its *look*, not its tooling.
+
+## Stack (unchanged)
+
+Next.js 16 App Router · React 19 · Tailwind v4 (PostCSS) · `output: 'export'` static ·
+GitHub Pages. `trailingSlash: true`, `images: { unoptimized: true }`. API routes stay
+`force-static`.
+
+## Copy constraints
+
+All public-facing prose follows `~/Workspace/personal-os/VOICE.md`:
+
+- Backticks around every identifier — file extensions (`` `.chd` ``), filenames
+  (`` `naomi.zip` ``), paths (`` `BIOS/` ``), URL schemes (`` `ifly://` ``).
+- Specific numbers, always (`1440p`, `4K`, `1K+ shaders`, `iPhone 16 Pro Max`).
+- No marketing speak, no closing-callback summary paragraphs. End on the last fact.
+- Banned phrases + soft-avoid vocabulary from VOICE.md apply. Em-dash cap 2/1000 words.
+- Honest about scope limits (e.g. iCloud sync covers saves/VMUs/BIOS but **not** ROMs;
+  DCNet is "what Flycast supports").
+
+---
+
+## Design System
+
+### Tokens (orange adaptation of the provenance retrowave system)
+
+Defined in `src/app/globals.css` via Tailwind v4 `@theme` + a few custom properties and
+keyframes.
+
+- **Primary gradient:** `linear-gradient(135deg, #ffab40 0%, #ff6900 50%, #d64500 100%)`
+  (amber → orange → deep). Used for gradient text ("i**Fly**"), pill buttons, icon boxes.
+- **Backgrounds:** layered near-black. Base `#0a0a0f`; alternating sections
+  `#0d0d14` / `#111119`. (Shift off the current flat `gray-950` so orange pops.)
+- **Grid overlay:** drifting grid in `rgba(255,105,0,0.08)`, `background-size: 40px 40px`,
+  `prov-grid-drift`-style keyframe, ~22s linear loop. Hero-only.
+- **Radial glow:** orange (`bg-orange-500/10 blur-3xl`) — already present in the hero, keep.
+- **Cards (glass):** `bg-white/[0.04]`, `border-white/[0.08]`, `--radius: 12px`,
+  hover-lift (`translateY(-6px)`) + shadow escalation.
+- **Icon boxes:** 64–70px, `border-radius: 16px`, tinted orange gradient background that
+  fills to solid primary gradient on hover (icon → white).
+- **Typography:** fluid `clamp()` headings (`h1: clamp(2rem, 5vw, 3.5rem)`), tight
+  letter-spacing (`-0.02em`), system font stack (already in place), body line-height 1.7.
+- **Easing:** `cubic-bezier(0.4, 0, 0.2, 1)` as a token; shadows `sm/md/lg`.
+
+### Reusable components (`src/components/ui/`)
+
+Each has one clear purpose and a small prop surface:
+
+| Component | Purpose |
+|-----------|---------|
+| `GridHero` | Full-bleed hero: animated grid overlay + radial glow + slotted content. |
+| `PageHeader` | Interior-page hero-lite: title + subtitle + subtle grid, no CTAs. |
+| `Section` | Vertical rhythm wrapper; optional alternating background + `container`. |
+| `Card` / `FeatureCard` | Glass card, hover-lift; `FeatureCard` adds gradient icon box + title + copy. |
+| `GradientButton` | Orange gradient pill w/ hover overlay + lift. Refactor `ButtonLink` to use it. |
+| `Accordion` + `AccordionItem` | Client component; collapsible Q&A (chevron rotates). Used by FAQ. |
+| `Callout` | Tip / warning / note box (e.g. "Prefer CHD or CDI over GDI"). Variants: `tip`, `warn`, `info`. |
+| `Badge` / `Pill` | Small rounded labels (platform badges, "Required" / "Optional" BIOS tags). |
+| `Screenshot` | Placeholder-aware image slot (caption + aspect box) so Joe can drop real images later. |
+
+`Navigation` and `Footer` get restyled (glassmorphism nav: `backdrop-blur`, `bg-*/80`,
+border) but stay in `src/components/`.
+
+### Screenshot placeholders
+
+`Screenshot` renders a labeled placeholder box (dimensions + caption) when no `src` is
+provided, and a real optimized image when it is. Every feature/guide section that wants a
+visual gets one now, so Joe can supply images without markup changes. Placeholder files
+live under `public/placeholders/` or are drawn via CSS; real images go in
+`src/images/...` following the existing WebP convention.
+
+---
+
+## Features (content)
+
+Grouped for the `/features` page (full) and the homepage (curated highlights). Every group
+gets a `Screenshot` slot. Copy uses VOICE.md rules — numbers + backticks, no fluff.
+
+**Performance & graphics**
+- Custom Metal backend.
+- Custom Apple-silicon CPU performance work → JIT-less full-speed emulation. Upscaling to
+  `1440p` or `4K` (e.g. iPhone 16 Pro Max).
+- `1K+` Metal shaders.
+- HDR "upscaling" support.
+- Custom texture-pack support (like Flycast) with a management UI.
+- ProMotion high-refresh support + original-refresh-rate locking.
+
+**VMU tooling (differentiators)**
+- Floating VMU window.
+- VMU Watch companion — live viewer on Apple Watch.
+- Custom Swift-native VMU file manager — per-game or per-VMU backup and restore.
+
+**Saves & sync**
+- iCloud sync of saves, VMUs, BIOS, etc. — **not** ROMs.
+- Auto timed saves — custom off-main-thread save-state serialization so emulation does not
+  stall (upstream Flycast serializes on the main thread).
+- HLE and native BIOS support.
+
+**Input & controls**
+- External controller haptics.
+- Jump Pack rumble → device haptics or external controller rumble (DualShock, DualSense,
+  Xbox).
+- Touch light-gun support.
+- On-screen touch keyboard/mouse + native Bluetooth keyboard/mouse & Smart Keyboard
+  (where the OS supports it).
+- Native CoreAudio microphone input.
+- Customizable, movable on-screen controls.
+- Remappable external controller buttons with presets.
+- DeltaSkin / ManicSkin controller-skin support.
+
+**Connectivity & display**
+- External display support (iOS / iPadOS).
+- DCNet network and LAN support (what Flycast supports).
+
+**Games & content**
+- In-app cheat-code database.
+- RetroAchievements support.
+- Online game-metadata lookup.
+- Per-game options tuning.
+
+**Import** (also detailed in `/guide/importing`)
+- WebDAV, HTTP, or Files.app import; drag-and-drop on iPad.
+
+**Platform & convenience**
+- iOS / iPadOS / tvOS.
+- Quick-launch recent-games Springboard widget.
+
+---
+
+## `/guide` Section
+
+Route group under `src/app/guide/`. Shared `layout.tsx` with sticky sub-nav (sidebar on
+desktop, horizontal scroller on mobile) + prev/next links. Each page is a server component
+exporting `metadata` (title, description, `alternates.canonical`); interactive bits (FAQ
+accordion) are client children. All pages get added to `sitemap.ts`.
+
+### Pages
+
+1. **`/guide` (index)** — overview + cards linking to each sub-page; quick "first import in
+   3 steps" summary.
+
+2. **`/guide/importing` — Importing Games**
+   - Methods: Files app / document picker; drag-and-drop (iPad, iOS 15+); Wi-Fi WebDAV
+     upload with QR (iOS/tvOS/macOS); `` `ifly://` `` URL scheme.
+   - Where files land: `` `ROMs/` ``, `` `BIOS/` ``, `` `Skins/` `` (Documents or Caches).
+   - Extraction behavior: disc archives (`` `.zip` ``/`` `.7z` `` containing `` `.gdi` ``/`` `.cue` ``)
+     are extracted; arcade romsets copied as-is; all-or-nothing rollback.
+
+3. **`/guide/formats` — Supported Formats**
+   - Full table:
+     - Standalone: `` `.iso` ``, `` `.cdi` ``, `` `.chd` ``.
+     - Index-based: `` `.gdi` `` (→ `` `.bin` ``/`` `.raw` ``/`` `.img` ``), `` `.cue` `` (→ `` `.bin` ``).
+     - Payload/tracks: `` `.bin` ``, `` `.raw` ``, `` `.img` ``, `` `.dat` ``, `` `.lst` ``.
+     - Playlist: `` `.m3u` `` (multi-disc).
+     - Homebrew: `` `.elf` ``.
+     - Archives: `` `.zip` ``, `` `.7z` ``.
+     - Skins: `` `.deltaskin` ``, `` `.manicskin` ``, `` `.skin` ``, `` `.emuskin` ``.
+   - `Callout` (tip): prefer `` `.chd` `` or `` `.cdi` `` over `` `.gdi` `` — single file,
+     nothing to lose from missing tracks; `` `.chd` `` is compressed (700 MB → ~300 MB).
+
+4. **`/guide/bios` — BIOS Setup**
+   - Headline: **Dreamcast needs no BIOS.** Almost every game runs on the built-in HLE
+     BIOS (Reios). `` `dc_boot.bin` `` + `` `dc_flash.bin` `` are optional (boot animation /
+     full accuracy).
+   - Required for arcade: `` `naomi.zip` ``, `` `naomi2.zip` ``, `` `awbios.zip` ``,
+     `` `segasp.zip` `` (MAME romsets; basename must match exactly).
+   - Optional game-specific: `` `hod2bios.zip` ``, `` `f355bios.zip` ``, `` `f355dlx.zip` ``,
+     `` `airlbios.zip` ``.
+   - Location: `` `BIOS/` `` folder; case-normalized to lowercase.
+   - `Badge` tags: Required / Optional per row.
+
+5. **`/guide/arcade` — Arcade & Naomi Rips** (the "weird formats" page; iFly's edge over
+   stock Flycast)
+   - Single decrypted `` `.bin` `` carts (archive.org style: `VirtuaFighter4.zip` →
+     `VirtuaFighter4.bin`, no `` `.ic*` `` chips) — iFly routes to the decrypted-ROM path
+     and auto-selects BIOS from the board header. Upstream Flycast fails these.
+   - Multi-track GD-ROM dumps (`` `.cue` `` + multiple `` `.bin` ``) — detected + extracted;
+     all tracks verified present.
+   - Naomi **GD-cartridge zip+CHD companion** layout: `` `senkosp.zip` `` +
+     `` `senkosp/gdl-0030a.chd` `` — iFly carries the sibling CHD alongside the cart zip and
+     warns if it is missing.
+   - MAME chip-set zips (`` `.ic*` ``) — copied as-is, opened by the MAME loader.
+
+6. **`/guide/systems` — Systems / Compatibility**
+   - Cards/table: Dreamcast, Naomi, Naomi 2, Atomiswave, System SP, plus game-specific
+     boards (House of the Dead 2, Ferrari F355, Airline Pilots). BIOS requirement + notes
+     per system.
+
+7. **`/guide/faq` — FAQ / Troubleshooting** (uses `Accordion`)
+   - Game won't boot → missing BIOS (arcade) or missing track (`` `.gdi` ``/`` `.cue` ``).
+   - Arcade rip fails → wrong archive shape; link to `/guide/arcade`.
+   - Multi-disc games → `` `.m3u` `` grouping.
+   - Save states / auto-saves / iCloud sync scope.
+   - Controllers → link existing `/controllers` page.
+   - Performance / upscaling tips.
+
+## Navigation changes
+
+Add **Guide** to the top nav, right after Downloads. Current items: Home, Downloads,
+About, Features, Support, Links, Donate, Status. Guide becomes a prominent primary entry
+(the `/guide` index links out to sub-pages via the guide layout's sub-nav). Nav restyled to
+glassmorphism.
+
+## Files to create / modify (indicative)
+
+**Create**
+- `src/components/ui/{GridHero,PageHeader,Section,Card,FeatureCard,GradientButton,Accordion,Callout,Badge,Screenshot}.tsx`
+- `src/app/guide/layout.tsx`
+- `src/app/guide/page.tsx`
+- `src/app/guide/{importing,formats,bios,arcade,systems,faq}/page.tsx`
+- `src/app/guide/faq/FaqAccordion.tsx` (client)
+
+**Modify**
+- `src/app/globals.css` (tokens, keyframes, utilities)
+- `src/components/Navigation.tsx`, `src/components/Footer.tsx`
+- `src/components/Features.tsx` (new grouped feature set)
+- `src/app/page.tsx` + all existing pages (restyle onto new components)
+- `src/app/sitemap.ts` (add guide routes)
+- `src/components/ButtonLink.tsx` (delegate to `GradientButton`)
+
+## Build sequence (for the plan)
+
+1. Design-system layer: tokens/keyframes in `globals.css` + `ui/` components.
+2. Restyle `Navigation` + `Footer`, add Guide nav item.
+3. `/guide` layout + the 7 guide pages (content-first, VOICE.md copy).
+4. Rewrite `Features.tsx` with the grouped feature set + homepage highlights.
+5. Restyle remaining existing pages onto the new components.
+6. Add guide routes to `sitemap.ts`; `npm run build` + `npm run type-check` + `npm run lint` clean.
+
+## Verification
+
+- `npm run type-check`, `npm run lint`, `npm run build` all pass (static export succeeds).
+- Every new page exports `metadata` with canonical; guide routes appear in
+  `out/sitemap.xml`.
+- CSP unchanged and still valid (no new external origins introduced).
+- Manual pass: nav highlights correct route; accordion opens/closes; placeholders render.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import DownloadSection from '@/components/DownloadSection';
 import SocialButton, { DiscordIcon, XIcon, BmcIcon, PatreonIcon } from '@/components/SocialButton';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'About',
@@ -11,14 +12,11 @@ export const metadata: Metadata = {
 
 export default function About() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader title="About iFly" />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-8 text-center">
-            About iFly
-          </h1>
-
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-4">
               What is iFly?
             </h2>
@@ -48,7 +46,7 @@ export default function About() {
                 ['iPad', 'Larger screen experience with enhanced controls', 'M4 2h16a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Zm8 18a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z'],
                 ['Apple TV', 'Big screen gaming with controller support', 'M2 6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Zm8 13h4v1H10v-1Z'],
               ] as const).map(([name, desc, path]) => (
-                <div key={name} className="flex flex-col items-center text-center p-5 bg-gray-800/40 border border-gray-700/50 rounded-xl">
+                <div key={name} className="flex flex-col items-center text-center p-5 card-glass">
                   <div className="w-11 h-11 rounded-xl bg-orange-500/10 ring-1 ring-orange-500/20 flex items-center justify-center text-orange-400 mb-3">
                     <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true"><path d={path} /></svg>
                   </div>
@@ -73,7 +71,7 @@ export default function About() {
             <h2 className="text-2xl font-semibold text-white mb-4 mt-8">
               System Requirements
             </h2>
-            <div className="bg-gray-800/40 border border-gray-700/50 p-4 rounded-xl">
+            <div className="card-glass p-4">
               <ul className="text-gray-400 space-y-1.5">
                 <li><span className="font-medium text-gray-300">iOS:</span> iOS 15.6 or later</li>
                 <li><span className="font-medium text-gray-300">tvOS:</span> tvOS 16.6 or later</li>
@@ -88,7 +86,7 @@ export default function About() {
 
           {/* Community + Donate */}
           <div className="grid sm:grid-cols-2 gap-4 mt-6">
-            <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 text-center">
+            <div className="card-glass p-6 text-center">
               <h2 className="text-xl font-bold text-white mb-2">Community</h2>
               <p className="text-gray-400 text-sm mb-5">Join for updates, tips, and support.</p>
               <div className="flex flex-col gap-3 items-center">
@@ -96,7 +94,7 @@ export default function About() {
                 <SocialButton href="https://x.com/ProvenanceApp" label="Follow on X/Twitter" leftIcon={<XIcon className="w-5 h-5" />} variant="x" />
               </div>
             </div>
-            <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 text-center">
+            <div className="card-glass p-6 text-center">
               <h2 className="text-xl font-bold text-white mb-2">Support Development</h2>
               <p className="text-gray-400 text-sm mb-5">Help keep iFly free and improving.</p>
               <div className="flex flex-col gap-3 items-center">

--- a/src/app/controllers/page.tsx
+++ b/src/app/controllers/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Recommended Controllers',
@@ -46,17 +47,14 @@ const picks: Pick[] = [
 
 export default function Controllers() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader
+        title="Recommended Controllers"
+        subtitle="Everything below pairs over Bluetooth and works with iFly out of the box."
+      />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-3xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-3 text-center">
-            Recommended Controllers
-          </h1>
-          <p className="text-center text-gray-500 mb-10">
-            Everything below pairs over Bluetooth and works with iFly out of the box.
-          </p>
-
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 space-y-8">
+          <div className="card-glass p-8 space-y-8">
             <section>
               <p className="text-gray-400 leading-relaxed">
                 iFly supports MFi controllers, PlayStation DualSense and DualShock 4, Xbox

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function DonatePage() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
       <section className="container mx-auto px-4 pt-12">
         <div className="max-w-4xl mx-auto">
           <div className="relative bg-gradient-to-br from-orange-700 to-orange-900 text-white rounded-2xl p-10 text-center shadow-xl shadow-orange-900/30 overflow-hidden">

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import path from 'path';
 import Link from 'next/link';
 import { parseBuilds } from '@/lib/buildParser';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Downloads',
@@ -35,25 +36,22 @@ export default function DownloadsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader
+        title="Downloads"
+        subtitle="Download iFly for iOS or tvOS. For sideloading with AltStore or SideStore, add our source feed."
+      />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-6xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 text-center">
-            Downloads
-          </h1>
-          <p className="text-lg text-gray-400 mb-8 text-center max-w-2xl mx-auto">
-            Download iFly for iOS or tvOS. For sideloading with AltStore or SideStore, add our source feed.
-          </p>
-
           {/* AltStore/SideStore Source */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 mb-6">
+          <div className="card-glass p-6 mb-6">
             <h2 className="text-2xl font-bold text-white mb-4">
               AltStore / SideStore Source
             </h2>
             <p className="text-gray-400 mb-4">
               Add our source to AltStore or SideStore for easy installation and automatic updates:
             </p>
-            <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 mb-4">
+            <div className="card-glass p-4 mb-4">
               <p className="text-xs text-gray-500 mb-1 uppercase tracking-wide">Source URL</p>
               <code className="text-sm text-orange-400 break-all">
                 {baseURL}/api/altstore
@@ -76,7 +74,7 @@ export default function DownloadsPage() {
               </a>
               <a
                 href="/api/altstore"
-                className="bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white px-6 py-3 rounded-lg font-semibold transition-colors border border-gray-700"
+                className="bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white px-6 py-3 rounded-lg font-semibold transition-colors border border-white/10"
                 data-proofer-ignore
               >
                 View JSON Feed
@@ -85,7 +83,7 @@ export default function DownloadsPage() {
           </div>
 
           {/* External Download Sources */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 mb-6">
+          <div className="card-glass p-6 mb-6">
             <h2 className="text-2xl font-bold text-white mb-4">
               Other Download Sources
             </h2>
@@ -96,7 +94,7 @@ export default function DownloadsPage() {
               href="https://provenance.itch.io/ifly"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-start gap-4 p-4 bg-gray-800/40 border border-gray-700/50 rounded-xl hover:border-gray-600 transition-colors group"
+              className="flex items-start gap-4 p-4 card-glass group"
             >
               <div className="w-10 h-10 rounded-lg bg-orange-500/10 ring-1 ring-orange-500/20 flex items-center justify-center text-orange-400 shrink-0">
                 <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true"><path d="M3 6.5C3 5.12 4.12 4 5.5 4h13c1.38 0 2.5 1.12 2.5 2.5v8.75A2.75 2.75 0 0 1 18.25 18H5.75A2.75 2.75 0 0 1 3 15.25V6.5Zm4.02-.75a2.75 2.75 0 0 0-2.75 2.75v4.5c0 1.518 1.232 2.75 2.75 2.75h9.96A2.75 2.75 0 0 0 19.73 13V8.5a2.75 2.75 0 0 0-2.75-2.75H7.02Zm5.48 2.25c1.494 0 2.75 1.256 2.75 2.75S14 13.5 12.5 13.5 9.75 12.244 9.75 10.75 11.006 8 12.5 8Z"/></svg>
@@ -110,7 +108,7 @@ export default function DownloadsPage() {
           </div>
 
           {/* iOS Downloads */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 mb-6">
+          <div className="card-glass p-6 mb-6">
             <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
               <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6 text-orange-400" aria-hidden="true"><path d="M7 2h10a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Zm5 18a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z"/></svg>
               iOS Builds
@@ -122,7 +120,7 @@ export default function DownloadsPage() {
                 {iosVersions.map((version, idx) => (
                   <div
                     key={idx}
-                    className="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 hover:border-gray-600 transition-colors"
+                    className="card-glass p-4"
                   >
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                       <div className="flex-1">
@@ -156,7 +154,7 @@ export default function DownloadsPage() {
           </div>
 
           {/* tvOS Downloads */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 mb-6">
+          <div className="card-glass p-6 mb-6">
             <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
               <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6 text-orange-400" aria-hidden="true"><path d="M2 6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Zm8 13h4v1H10v-1Z"/></svg>
               tvOS Builds
@@ -168,7 +166,7 @@ export default function DownloadsPage() {
                 {tvosVersions.map((version, idx) => (
                   <div
                     key={idx}
-                    className="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 hover:border-gray-600 transition-colors"
+                    className="card-glass p-4"
                   >
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                       <div className="flex-1">
@@ -202,7 +200,7 @@ export default function DownloadsPage() {
           </div>
 
           {/* Installation Instructions */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6">
+          <div className="card-glass p-6">
             <h2 className="text-2xl font-bold text-white mb-4">
               Installation Instructions
             </h2>

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import Features from '@/components/Features';
 import SocialButton, { DiscordIcon, XIcon } from '@/components/SocialButton';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Features',
@@ -11,21 +12,17 @@ export const metadata: Metadata = {
 
 export default function FeaturesPage() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader
+        title="Features"
+        subtitle="A modern Dreamcast emulation experience tailored for iPhone, iPad, and Apple TV. iFly focuses on smooth performance, robust controller support, and a clean interface designed for iOS and tvOS."
+      />
       <section className="container mx-auto px-4 py-16">
         <div className="max-w-5xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 text-center">
-            Features
-          </h1>
-          <p className="text-gray-400 mb-10 text-center max-w-3xl mx-auto">
-            A modern Dreamcast emulation experience tailored for iPhone, iPad, and Apple TV. iFly focuses on smooth
-            performance, robust controller support, and a clean interface designed for iOS and tvOS.
-          </p>
-
           <Features />
 
           {/* Bottom CTAs */}
-          <div className="mt-14 bg-gray-900 border border-gray-800 rounded-2xl p-8 text-center">
+          <div className="mt-14 card-glass p-8 text-center">
             <h2 className="text-xl font-bold text-white mb-2">Join the Community</h2>
             <p className="text-gray-400 text-sm mb-6">Get help, share tips, and stay updated on new releases.</p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-6">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,10 +3,87 @@
 @theme inline {
   --font-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   --font-mono: 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+
+  /* Layered near-black backgrounds (exposes bg-ink / bg-ink-2 / bg-ink-3 utilities) */
+  --color-ink: #0a0a0f;
+  --color-ink-2: #0d0d14;
+  --color-ink-3: #111119;
+}
+
+:root {
+  --gradient-primary: linear-gradient(135deg, #ffab40 0%, #ff6900 50%, #d64500 100%);
+  --gradient-primary-hover: linear-gradient(135deg, #ffbe5c 0%, #ff7d1f 50%, #f0530f 100%);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+  --radius-card: 12px;
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.55);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.65);
 }
 
 body {
-  background-color: #030712; /* gray-950 */
+  background-color: var(--color-ink);
   color: #ededed;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+h1, h2 { letter-spacing: -0.02em; }
+
+/* Gradient text (orange). Apply to a span/heading. */
+.text-gradient {
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Animated drifting grid overlay — absolute child of a relative hero. */
+.grid-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 105, 0, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 105, 0, 0.08) 1px, transparent 1px);
+  background-size: 40px 40px;
+  animation: grid-drift 22s linear infinite;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%);
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%);
+}
+
+@keyframes grid-drift {
+  from { background-position: 0 0, 0 0; }
+  to   { background-position: 40px 40px, 40px 40px; }
+}
+
+/* Glass card */
+.card-glass {
+  background-color: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-card);
+  transition: transform 0.3s var(--ease-smooth), box-shadow 0.3s var(--ease-smooth), border-color 0.3s var(--ease-smooth);
+}
+.card-glass:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+  border-color: rgba(255, 105, 0, 0.35);
+}
+
+/* Gradient pill button */
+.btn-gradient {
+  position: relative;
+  background: var(--gradient-primary);
+  color: #fff;
+  border-radius: 9999px;
+  transition: transform 0.3s var(--ease-smooth), box-shadow 0.3s var(--ease-smooth), filter 0.3s var(--ease-smooth);
+  box-shadow: 0 6px 20px rgba(255, 105, 0, 0.25);
+}
+.btn-gradient:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.08);
+  box-shadow: 0 10px 28px rgba(255, 105, 0, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grid-overlay { animation: none; }
+  .card-glass:hover, .btn-gradient:hover { transform: none; }
 }

--- a/src/app/guide/arcade/page.tsx
+++ b/src/app/guide/arcade/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+
+export const metadata: Metadata = {
+  title: 'Arcade & Naomi Rips',
+  description: 'How iFly handles Naomi, Naomi 2, and Atomiswave rips in odd formats — decrypted single-cart bins, multi-track GD-ROM dumps, and GD-cartridge zip+CHD layouts.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/arcade/' },
+};
+
+export default function ArcadePage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Arcade &amp; Naomi Rips</h1>
+      <p className="mt-3 text-gray-400">
+        Naomi, Naomi 2, and Atomiswave rips arrive in several shapes. iFly detects each and
+        routes it correctly — including formats stock Flycast can&apos;t open. You still need the
+        matching arcade BIOS (see <a href="/guide/bios/" className="text-orange-300 hover:underline">BIOS Setup</a>).
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold text-white">Decrypted single-cart ROMs</h2>
+      <p className="mt-2 text-gray-400">
+        Many archive.org rips are a single decrypted <code>.bin</code> named after the game, e.g.
+        <code>VirtuaFighter4.zip</code> containing <code>VirtuaFighter4.bin</code> with no
+        <code>.ic*</code> chip files. iFly detects the single-cart shape, routes it to the
+        decrypted-ROM path, and Flycast peeks the board header (<code>NAOMI</code> /
+        <code>Naomi2</code>) to auto-select the BIOS. Stock Flycast sends these to its MAME loader
+        and fails.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Multi-track GD-ROM dumps</h2>
+      <p className="mt-2 text-gray-400">
+        Arcade GD-ROM games sometimes come as a <code>.cue</code> plus several <code>.bin</code>
+        tracks (e.g. Slashout). iFly treats the <code>.cue</code> as a disc, extracts it like a
+        Dreamcast multi-track set, and verifies every referenced track exists.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Naomi GD-cartridge (zip + CHD)</h2>
+      <p className="mt-2 text-gray-400">
+        Some Naomi games pair a MAME cart zip with a GD-ROM image in a subfolder:
+        <code>senkosp.zip</code> alongside <code>senkosp/gdl-0030a.chd</code>. iFly carries the
+        sibling CHD with the cart zip on import and warns if the CHD is missing before boot.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">MAME chip-set zips</h2>
+      <p className="mt-2 text-gray-400">
+        Traditional MAME romsets (a <code>.zip</code> of <code>.ic*</code> chip files) are copied
+        as-is and opened directly by the MAME loader.
+      </p>
+
+      <Callout variant="warn" title="If an arcade game won't boot">
+        Check that the arcade BIOS (<code>naomi.zip</code>, <code>naomi2.zip</code>,
+        <code>awbios.zip</code>, or <code>segasp.zip</code>) is in <code>BIOS/</code>, and that a
+        GD-cartridge game&apos;s companion <code>.chd</code> sits in its named subfolder.
+      </Callout>
+    </>
+  );
+}

--- a/src/app/guide/arcade/page.tsx
+++ b/src/app/guide/arcade/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import Callout from '@/components/ui/Callout';
 
 export const metadata: Metadata = {
@@ -14,7 +15,7 @@ export default function ArcadePage() {
       <p className="mt-3 text-gray-400">
         Naomi, Naomi 2, and Atomiswave rips arrive in several shapes. iFly detects each and
         routes it correctly — including formats stock Flycast can&apos;t open. You still need the
-        matching arcade BIOS (see <a href="/guide/bios/" className="text-orange-300 hover:underline">BIOS Setup</a>).
+        matching arcade BIOS (see <Link href="/guide/bios/" className="text-orange-300 hover:underline">BIOS Setup</Link>).
       </p>
 
       <h2 className="mt-10 text-xl font-semibold text-white">Decrypted single-cart ROMs</h2>

--- a/src/app/guide/bios/page.tsx
+++ b/src/app/guide/bios/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+import { Badge } from '@/components/ui/Badge';
+
+export const metadata: Metadata = {
+  title: 'BIOS Setup',
+  description: 'Dreamcast needs no BIOS in iFly. Only the arcade systems require one — here are the exact files and where they go.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/bios/' },
+};
+
+const biosRows: { system: string; file: string; required: boolean; notes: string }[] = [
+  { system: 'Dreamcast', file: 'dc_boot.bin', required: false, notes: 'Boot animation only. HLE BIOS (Reios) is used by default.' },
+  { system: 'Dreamcast', file: 'dc_flash.bin', required: false, notes: 'Flash / NVRAM (clock, settings). Pair with dc_boot.bin for full accuracy.' },
+  { system: 'Naomi', file: 'naomi.zip', required: true, notes: 'MAME romset. Basename must match exactly.' },
+  { system: 'Naomi 2', file: 'naomi2.zip', required: true, notes: 'MAME romset.' },
+  { system: 'Atomiswave', file: 'awbios.zip', required: true, notes: 'MAME romset.' },
+  { system: 'System SP', file: 'segasp.zip', required: true, notes: 'MAME romset.' },
+  { system: 'House of the Dead 2', file: 'hod2bios.zip', required: false, notes: 'Game-specific board.' },
+  { system: 'Ferrari F355', file: 'f355bios.zip / f355dlx.zip', required: false, notes: 'Challenge / Deluxe variants.' },
+  { system: 'Airline Pilots', file: 'airlbios.zip', required: false, notes: 'Also covers Sega Strike Fighter.' },
+];
+
+export default function BiosPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">BIOS Setup</h1>
+
+      <Callout variant="tip" title="Dreamcast needs no BIOS">
+        Almost every Dreamcast game runs on iFly&apos;s built-in HLE BIOS (Reios). You only need
+        a real BIOS for the arcade systems (Naomi, Naomi 2, Atomiswave, System SP).
+      </Callout>
+
+      <p className="mt-6 text-gray-400">
+        Put BIOS files in the <code>BIOS/</code> folder. Names are case-normalized to lowercase,
+        and MAME romsets must keep their exact basename.
+      </p>
+
+      <div className="mt-8 overflow-x-auto rounded-xl border border-white/10">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.03] text-gray-300">
+            <tr>
+              <th className="px-4 py-3 font-semibold">System</th>
+              <th className="px-4 py-3 font-semibold">File</th>
+              <th className="px-4 py-3 font-semibold">Required</th>
+              <th className="px-4 py-3 font-semibold">Notes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5 text-gray-400">
+            {biosRows.map((r) => (
+              <tr key={`${r.system}-${r.file}`} className="align-top">
+                <td className="px-4 py-3 whitespace-nowrap">{r.system}</td>
+                <td className="px-4 py-3"><code className="text-orange-300">{r.file}</code></td>
+                <td className="px-4 py-3">
+                  <Badge tone={r.required ? 'required' : 'optional'}>{r.required ? 'Required' : 'Optional'}</Badge>
+                </td>
+                <td className="px-4 py-3">{r.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/src/app/guide/faq/FaqAccordion.tsx
+++ b/src/app/guide/faq/FaqAccordion.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import Accordion, { type AccordionItemData } from '@/components/ui/Accordion';
 
 const items: AccordionItemData[] = [
@@ -20,7 +21,7 @@ const items: AccordionItemData[] = [
     a: (
       <>
         Arcade rips come in several shapes. See{' '}
-        <a href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</a>{' '}
+        <Link href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</Link>{' '}
         for decrypted single-cart <code>.bin</code> dumps, multi-track GD-ROM dumps, and Naomi
         GD-cartridge <code>zip</code>+<code>.chd</code> layouts.
       </>
@@ -57,7 +58,7 @@ const items: AccordionItemData[] = [
     q: 'How do I set up controllers?',
     a: (
       <>
-        See the <a href="/controllers/" className="text-orange-300 hover:underline">Controllers</a>{' '}
+        See the <Link href="/controllers/" className="text-orange-300 hover:underline">Controllers</Link>{' '}
         page for MFi, DualShock, DualSense, Xbox, and Switch mappings, plus on-screen control
         options.
       </>

--- a/src/app/guide/faq/FaqAccordion.tsx
+++ b/src/app/guide/faq/FaqAccordion.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import Accordion, { type AccordionItemData } from '@/components/ui/Accordion';
+
+const items: AccordionItemData[] = [
+  {
+    q: 'My game won\'t boot. What\'s wrong?',
+    a: (
+      <>
+        For arcade games, confirm the arcade BIOS (<code>naomi.zip</code>, <code>naomi2.zip</code>,
+        <code>awbios.zip</code>, <code>segasp.zip</code>) is in <code>BIOS/</code>. For a
+        <code>.gdi</code> or <code>.cue</code>, confirm every referenced track
+        (<code>.bin</code>/<code>.raw</code>/<code>.img</code>) is present. Prefer a single-file
+        <code>.chd</code> or <code>.cdi</code> to avoid missing-track problems.
+      </>
+    ),
+  },
+  {
+    q: 'An arcade rip fails to import or load.',
+    a: (
+      <>
+        Arcade rips come in several shapes. See{' '}
+        <a href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</a>{' '}
+        for decrypted single-cart <code>.bin</code> dumps, multi-track GD-ROM dumps, and Naomi
+        GD-cartridge <code>zip</code>+<code>.chd</code> layouts.
+      </>
+    ),
+  },
+  {
+    q: 'How do I add a multi-disc game?',
+    a: (
+      <>
+        Import each disc, then use an <code>.m3u</code> playlist listing the disc images in order.
+        iFly groups them as one multi-disc game.
+      </>
+    ),
+  },
+  {
+    q: 'What syncs over iCloud?',
+    a: (
+      <>
+        Saves, VMUs, and BIOS sync across your devices over iCloud. ROMs do not sync — import
+        those on each device.
+      </>
+    ),
+  },
+  {
+    q: 'Do auto-saves interrupt gameplay?',
+    a: (
+      <>
+        No. iFly serializes save states off the main thread, so timed auto-saves run without
+        stalling emulation.
+      </>
+    ),
+  },
+  {
+    q: 'How do I set up controllers?',
+    a: (
+      <>
+        See the <a href="/controllers/" className="text-orange-300 hover:underline">Controllers</a>{' '}
+        page for MFi, DualShock, DualSense, Xbox, and Switch mappings, plus on-screen control
+        options.
+      </>
+    ),
+  },
+  {
+    q: 'How do I get better performance or higher resolution?',
+    a: (
+      <>
+        iFly runs JIT-less at full speed on Apple silicon and can upscale to <code>1440p</code> or
+        <code>4K</code> on recent devices. Use per-game options to tune internal resolution,
+        frame pacing, and ProMotion refresh.
+      </>
+    ),
+  },
+];
+
+export default function FaqAccordion() {
+  return <Accordion items={items} />;
+}

--- a/src/app/guide/faq/page.tsx
+++ b/src/app/guide/faq/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import FaqAccordion from './FaqAccordion';
+
+export const metadata: Metadata = {
+  title: 'FAQ & Troubleshooting',
+  description: 'Fixes for the common iFly problems: games that won\'t boot, arcade rip failures, multi-disc games, iCloud sync, and performance.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/faq/' },
+};
+
+export default function FaqPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">FAQ &amp; Troubleshooting</h1>
+      <p className="mt-3 mb-8 text-gray-400">
+        The common failures and how to fix them. Still stuck? Ask in the{' '}
+        <a href="https://discord.gg/QF5ZjVT4Sa" target="_blank" rel="noopener noreferrer" className="text-orange-300 hover:underline">Discord</a>.
+      </p>
+      <FaqAccordion />
+    </>
+  );
+}

--- a/src/app/guide/formats/page.tsx
+++ b/src/app/guide/formats/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import Callout from '@/components/ui/Callout';
 
 export const metadata: Metadata = {
@@ -28,7 +29,7 @@ export default function FormatsPage() {
       <h1 className="text-3xl font-black text-white">Supported Formats</h1>
       <p className="mt-3 text-gray-400">
         iFly reads the same disc and arcade formats as Flycast, plus extra handling for odd
-        arcade rips (see <a href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</a>).
+        arcade rips (see <Link href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</Link>).
       </p>
 
       <Callout variant="tip" title="Prefer CHD or CDI over GDI">

--- a/src/app/guide/formats/page.tsx
+++ b/src/app/guide/formats/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+
+export const metadata: Metadata = {
+  title: 'Supported Formats',
+  description: 'Every disc image, track, archive, and skin format iFly supports, and why to prefer CHD or CDI over GDI.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/formats/' },
+};
+
+const rows: [string, string, string][] = [
+  ['.chd', 'Standalone disc', 'Compressed, single file. Best storage (~700 MB → ~300 MB). Dreamcast + Naomi GD-ROM.'],
+  ['.cdi', 'Standalone disc', 'Single-file Dreamcast image. No tracks to lose.'],
+  ['.iso', 'Standalone disc', 'Single-file image.'],
+  ['.gdi', 'Index', 'GD-ROM index that points at .bin / .raw / .img tracks. All tracks must be present.'],
+  ['.cue', 'Index', 'CUE sheet that points at .bin tracks.'],
+  ['.bin / .raw / .img', 'Track', 'Payload tracks referenced by a .gdi or .cue.'],
+  ['.dat', 'Arcade payload', 'Decrypted single-cart arcade ROM (often inside a .zip).'],
+  ['.lst', 'Arcade list', 'Metadata for MAME-style arcade rips.'],
+  ['.m3u', 'Playlist', 'Groups multiple discs into an ordered multi-disc set.'],
+  ['.elf', 'Homebrew', 'Raw homebrew executable.'],
+  ['.zip / .7z', 'Archive', 'Disc archives are extracted; arcade romsets copied as-is.'],
+  ['.deltaskin / .manicskin / .skin / .emuskin', 'Controller skin', 'Routed to the Skins folder.'],
+];
+
+export default function FormatsPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Supported Formats</h1>
+      <p className="mt-3 text-gray-400">
+        iFly reads the same disc and arcade formats as Flycast, plus extra handling for odd
+        arcade rips (see <a href="/guide/arcade/" className="text-orange-300 hover:underline">Arcade &amp; Naomi Rips</a>).
+      </p>
+
+      <Callout variant="tip" title="Prefer CHD or CDI over GDI">
+        A <code>.chd</code> or <code>.cdi</code> is a single file — nothing to lose. A
+        <code>.gdi</code> references separate <code>.bin</code>/<code>.raw</code> tracks, and the
+        game will not boot if any track is missing. <code>.chd</code> is also compressed, roughly
+        halving disk use.
+      </Callout>
+
+      <div className="mt-8 overflow-x-auto rounded-xl border border-white/10">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.03] text-gray-300">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Extension</th>
+              <th className="px-4 py-3 font-semibold">Kind</th>
+              <th className="px-4 py-3 font-semibold">Notes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5 text-gray-400">
+            {rows.map(([ext, kind, notes]) => (
+              <tr key={ext} className="align-top">
+                <td className="px-4 py-3"><code className="text-orange-300">{ext}</code></td>
+                <td className="px-4 py-3 whitespace-nowrap">{kind}</td>
+                <td className="px-4 py-3">{notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/src/app/guide/guideNav.ts
+++ b/src/app/guide/guideNav.ts
@@ -1,0 +1,11 @@
+export type GuidePage = { href: string; label: string; blurb: string };
+
+export const GUIDE_PAGES: GuidePage[] = [
+  { href: '/guide/', label: 'Overview', blurb: 'Start here — get your first game running.' },
+  { href: '/guide/importing/', label: 'Importing Games', blurb: 'Files app, drag-and-drop, Wi-Fi upload, and URL scheme.' },
+  { href: '/guide/formats/', label: 'Supported Formats', blurb: 'Every extension iFly reads, and which to prefer.' },
+  { href: '/guide/bios/', label: 'BIOS Setup', blurb: 'When you need a BIOS and where it goes.' },
+  { href: '/guide/arcade/', label: 'Arcade & Naomi Rips', blurb: 'Naomi, Naomi 2, and Atomiswave in odd formats.' },
+  { href: '/guide/systems/', label: 'Systems', blurb: 'Every system iFly runs, with per-system notes.' },
+  { href: '/guide/faq/', label: 'FAQ & Troubleshooting', blurb: 'Fixes for the common failures.' },
+];

--- a/src/app/guide/importing/page.tsx
+++ b/src/app/guide/importing/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next';
+import Callout from '@/components/ui/Callout';
+import Screenshot from '@/components/ui/Screenshot';
+
+export const metadata: Metadata = {
+  title: 'Importing Games',
+  description: 'Import Dreamcast and arcade games into iFly via the Files app, drag-and-drop, Wi-Fi upload, or the ifly:// URL scheme.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/importing/' },
+};
+
+export default function ImportingPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Importing Games</h1>
+      <p className="mt-3 text-gray-400">
+        iFly imports games four ways. All of them route through the same importer, so the file
+        ends up in the right place no matter which you use.
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold text-white">Files app / document picker</h2>
+      <p className="mt-2 text-gray-400">
+        In iFly, add games from the Files app. Pick a single file (<code>.chd</code>,
+        <code>.cdi</code>, <code>.gdi</code>) or a whole folder for multi-track dumps. This works
+        on iOS, iPadOS, and tvOS.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Drag-and-drop (iPad)</h2>
+      <p className="mt-2 text-gray-400">
+        On iPad (iOS 15+), drag files from Files, Safari downloads, or another app straight onto
+        the iFly library grid.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold text-white">Wi-Fi upload (WebDAV / HTTP)</h2>
+      <p className="mt-2 text-gray-400">
+        Start the built-in web server in iFly, then scan the QR code or open the shown URL in a
+        desktop browser and drag files in. Works over WebDAV or plain HTTP on iOS, tvOS, and
+        macOS — the easiest way to move large arcade sets onto Apple TV.
+      </p>
+      <Screenshot alt="Wi-Fi upload screen with QR code" width={1200} height={800} className="mt-4" />
+
+      <h2 className="mt-8 text-xl font-semibold text-white">URL scheme</h2>
+      <p className="mt-2 text-gray-400">
+        Links using the <code>ifly://</code> scheme open a file and import it through the same
+        policy.
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold text-white">Where files go</h2>
+      <p className="mt-2 text-gray-400">
+        Games land in <code>ROMs/</code>, BIOS in <code>BIOS/</code>, controller skins in
+        <code>Skins/</code> (under Documents or Caches). Skins (<code>.deltaskin</code>,
+        <code>.manicskin</code>) are routed to <code>Skins/</code> automatically.
+      </p>
+
+      <Callout variant="info" title="What happens to archives">
+        Disc archives (a <code>.zip</code> or <code>.7z</code> containing a <code>.gdi</code> or
+        <code>.cue</code>) are extracted on import. Arcade romsets are copied as-is so the MAME
+        loader can open them in place. Extraction is all-or-nothing: a partial extract rolls back
+        and leaves the source archive alone.
+      </Callout>
+    </>
+  );
+}

--- a/src/app/guide/layout.tsx
+++ b/src/app/guide/layout.tsx
@@ -36,7 +36,7 @@ export default function GuideLayout({ children }: { children: React.ReactNode })
 
         {/* Content */}
         <div className="min-w-0">
-          <article className="prose-guide max-w-none">{children}</article>
+          <article className="max-w-none">{children}</article>
 
           {(prev || next) && (
             <div className="mt-12 flex items-center justify-between gap-4 border-t border-white/10 pt-6">

--- a/src/app/guide/layout.tsx
+++ b/src/app/guide/layout.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { GUIDE_PAGES } from './guideNav';
+
+export default function GuideLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  const currentIndex = GUIDE_PAGES.findIndex((p) => p.href === normalized);
+  const prev = currentIndex > 0 ? GUIDE_PAGES[currentIndex - 1] : null;
+  const next = currentIndex >= 0 && currentIndex < GUIDE_PAGES.length - 1 ? GUIDE_PAGES[currentIndex + 1] : null;
+
+  return (
+    <div className="container mx-auto px-4 py-10">
+      <div className="grid gap-10 lg:grid-cols-[220px_1fr]">
+        {/* Sub-nav */}
+        <aside className="lg:sticky lg:top-24 lg:self-start">
+          <nav aria-label="Guide navigation" className="flex gap-2 overflow-x-auto lg:flex-col lg:gap-1">
+            {GUIDE_PAGES.map((p) => {
+              const active = p.href === normalized;
+              return (
+                <Link
+                  key={p.href}
+                  href={p.href}
+                  className={`whitespace-nowrap rounded-md px-3 py-2 text-sm transition-colors ${
+                    active ? 'bg-orange-500/15 font-medium text-orange-300' : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                  }`}
+                >
+                  {p.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+
+        {/* Content */}
+        <div className="min-w-0">
+          <article className="prose-guide max-w-none">{children}</article>
+
+          {(prev || next) && (
+            <div className="mt-12 flex items-center justify-between gap-4 border-t border-white/10 pt-6">
+              {prev ? (
+                <Link href={prev.href} className="text-sm text-gray-400 hover:text-orange-300">
+                  ← {prev.label}
+                </Link>
+              ) : <span />}
+              {next ? (
+                <Link href={next.href} className="text-sm text-gray-400 hover:text-orange-300">
+                  {next.label} →
+                </Link>
+              ) : <span />}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { GUIDE_PAGES } from './guideNav';
+
+export const metadata: Metadata = {
+  title: 'Guide',
+  description: 'How to import games, which formats iFly supports, BIOS setup, arcade and Naomi rips, and troubleshooting.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/' },
+};
+
+export default function GuideIndex() {
+  const pages = GUIDE_PAGES.filter((p) => p.href !== '/guide/');
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">iFly Guide</h1>
+      <p className="mt-3 max-w-2xl text-gray-400">
+        Everything you need to get games running on iFly. New here? Most Dreamcast games need
+        no BIOS at all — drop a <code>.chd</code> or <code>.cdi</code> into iFly and go.
+      </p>
+
+      <div className="mt-8 rounded-xl border border-orange-500/20 bg-orange-500/[0.06] p-5">
+        <h2 className="text-lg font-semibold text-white">First import in 3 steps</h2>
+        <ol className="mt-3 list-decimal space-y-1 pl-5 text-sm text-gray-300">
+          <li>Get a Dreamcast game as <code>.chd</code>, <code>.cdi</code>, or <code>.gdi</code>.</li>
+          <li>Open iFly → import via the Files app, drag-and-drop, or Wi-Fi upload.</li>
+          <li>Tap the game. No BIOS required for Dreamcast.</li>
+        </ol>
+      </div>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {pages.map((p) => (
+          <Link key={p.href} href={p.href} className="card-glass block p-5">
+            <h3 className="font-semibold text-white">{p.label}</h3>
+            <p className="mt-1 text-sm text-gray-400">{p.blurb}</p>
+          </Link>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/guide/systems/page.tsx
+++ b/src/app/guide/systems/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next';
+import { Badge } from '@/components/ui/Badge';
+
+export const metadata: Metadata = {
+  title: 'Systems',
+  description: 'Every system iFly runs: Dreamcast, Naomi, Naomi 2, Atomiswave, System SP, and game-specific boards.',
+  alternates: { canonical: 'https://ifly-emu.com/guide/systems/' },
+};
+
+const systems: { name: string; biosRequired: boolean; notes: string }[] = [
+  { name: 'Dreamcast', biosRequired: false, notes: 'Consumer console. Runs on the built-in HLE BIOS; no BIOS file needed.' },
+  { name: 'Naomi', biosRequired: true, notes: 'Arcade board. Requires naomi.zip.' },
+  { name: 'Naomi 2', biosRequired: true, notes: 'Upgraded arcade board. Requires naomi2.zip.' },
+  { name: 'Atomiswave', biosRequired: true, notes: 'Sammy arcade hardware. Requires awbios.zip.' },
+  { name: 'System SP ("Spider")', biosRequired: true, notes: 'Sega arcade system. Requires segasp.zip.' },
+  { name: 'Game-specific boards', biosRequired: false, notes: 'House of the Dead 2, Ferrari F355, Airline Pilots — optional per-game BIOS.' },
+];
+
+export default function SystemsPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-black text-white">Systems</h1>
+      <p className="mt-3 text-gray-400">
+        iFly runs the Sega Dreamcast plus the arcade platforms it shares hardware with. Arcade
+        systems need a BIOS; Dreamcast does not.
+      </p>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {systems.map((s) => (
+          <div key={s.name} className="card-glass p-5">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="font-semibold text-white">{s.name}</h2>
+              <Badge tone={s.biosRequired ? 'required' : 'optional'}>
+                {s.biosRequired ? 'BIOS required' : 'No BIOS'}
+              </Badge>
+            </div>
+            <p className="mt-2 text-sm text-gray-400">{s.notes}</p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/licenses/page.tsx
+++ b/src/app/licenses/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Licenses & Acknowledgements',
@@ -67,17 +68,14 @@ const components: Component[] = [
 
 export default function Licenses() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader
+        title="Licenses & Acknowledgements"
+        subtitle="Open-source components used in iFly EMU."
+      />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-3xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-3 text-center">
-            Licenses &amp; Acknowledgements
-          </h1>
-          <p className="text-center text-gray-500 mb-10">
-            Open-source components used in iFly EMU.
-          </p>
-
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 space-y-8">
+          <div className="card-glass p-8 space-y-8">
             <section>
               <p className="text-gray-400 leading-relaxed">
                 iFly EMU is built on Flycast and a number of open-source libraries. Each project

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -132,7 +132,7 @@ export default function Links() {
               <ExternalCard
                 href="https://icube-emu.com"
                 title="iCube"
-                description="iOS port of Dolphin — GameCube &amp; Wii emulation"
+                description="iOS port of Dolphin — GameCube & Wii emulation"
                 iconPath="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
                 iconColor="text-blue-400" iconBg="bg-blue-500/10"
                 proofIgnore

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import DownloadSection from '@/components/DownloadSection';
 import SocialButton, { DiscordIcon, XIcon, BmcIcon, PatreonIcon } from '@/components/SocialButton';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Links',
@@ -15,7 +16,7 @@ const ExternalCard = ({ href, title, description, iconPath, iconColor = 'text-gr
 }) => (
   <a href={href} target="_blank" rel="noopener noreferrer"
      {...(proofIgnore ? { 'data-proofer-ignore': '' } : {})}
-     className="flex items-start gap-4 p-4 bg-gray-800/40 border border-gray-700/50 rounded-xl hover:border-gray-600 transition-colors group">
+     className="flex items-start gap-4 p-4 card-glass group">
     <div className={`w-10 h-10 rounded-lg ${iconBg} flex items-center justify-center ${iconColor} shrink-0`}>
       <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true">
         <path d={iconPath} />
@@ -30,21 +31,18 @@ const ExternalCard = ({ href, title, description, iconPath, iconColor = 'text-gr
 
 export default function Links() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader title="Links & Resources" />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-8 text-center">
-            Links &amp; Resources
-          </h1>
-
           {/* Download */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-6">Download iFly</h2>
             <DownloadSection showEmbed />
           </div>
 
           {/* Flycast Resources */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-2">Flycast Resources</h2>
             <p className="text-gray-400 text-sm mb-6">iFly is built on Flycast. These resources cover the underlying emulator.</p>
             <div className="grid md:grid-cols-2 gap-3">
@@ -82,7 +80,7 @@ export default function Links() {
           </div>
 
           {/* Community */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-6">Community &amp; Social</h2>
             <div className="grid md:grid-cols-3 gap-3">
               <ExternalCard
@@ -110,7 +108,7 @@ export default function Links() {
           </div>
 
           {/* Support Development */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-2">Support Development</h2>
             <p className="text-gray-400 text-sm mb-6">Help keep iFly free and actively developed.</p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
@@ -120,7 +118,7 @@ export default function Links() {
           </div>
 
           {/* Related Projects */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8">
+          <div className="card-glass p-8">
             <h2 className="text-2xl font-semibold text-white mb-2">Related Projects</h2>
             <p className="text-gray-400 text-sm mb-6">Other emulators from the same team.</p>
             <div className="grid md:grid-cols-2 gap-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
 
       {/* Hero */}
       <GridHero className="pt-20 pb-16 text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
+import GridHero from '@/components/ui/GridHero';
+import Section from '@/components/ui/Section';
+import GradientButton from '@/components/ui/GradientButton';
 import iphone1 from '@/images/screenshots/ios/iphone1-library.webp';
 import iphone2 from '@/images/screenshots/ios/iphone2-settings.webp';
 import iphone3 from '@/images/screenshots/ios/iphone3-emu.webp';
@@ -29,12 +32,7 @@ export default function Home() {
     <div className="min-h-screen bg-gray-950">
 
       {/* Hero */}
-      <section className="relative container mx-auto px-4 pt-20 pb-16 text-center overflow-hidden">
-        {/* Radial glow */}
-        <div className="absolute inset-0 -z-10 overflow-hidden pointer-events-none" aria-hidden="true">
-          <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[600px] rounded-full bg-orange-500/10 blur-3xl" />
-          <div className="absolute top-20 left-1/2 -translate-x-1/2 w-[400px] h-[400px] rounded-full bg-orange-600/5 blur-2xl" />
-        </div>
+      <GridHero className="pt-20 pb-16 text-center">
         <div className="max-w-3xl mx-auto">
 
           {/* App icon — priority ensures it's preloaded as the LCP element */}
@@ -50,7 +48,7 @@ export default function Home() {
           </div>
 
           <h1 className="text-6xl md:text-7xl font-black text-white mb-3 tracking-tight">
-            i<span className="text-orange-500">Fly</span>
+            i<span className="text-gradient">Fly</span>
           </h1>
 
           <p className="text-2xl md:text-3xl font-semibold text-orange-400 mb-5">
@@ -76,21 +74,11 @@ export default function Home() {
 
           {/* Primary CTAs */}
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
-            <Link
-              href="/testflight/"
-              className="bg-orange-700 hover:bg-orange-600 text-white px-8 py-3 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-700/25"
-            >
-              TestFlight Beta
-            </Link>
-            <Link
-              href="/downloads/"
-              className="bg-gray-800 hover:bg-gray-700 text-white px-8 py-3 rounded-xl font-semibold text-lg transition-colors border border-gray-700"
-            >
-              Download IPA
-            </Link>
+            <GradientButton href="/testflight/">TestFlight Beta</GradientButton>
+            <GradientButton href="/downloads/" variant="outline">Download IPA</GradientButton>
           </div>
         </div>
-      </section>
+      </GridHero>
 
       {/* Stats row */}
       <section className="container mx-auto px-4 pb-12">
@@ -101,7 +89,7 @@ export default function Home() {
             ['3', 'Platforms'],
             ['Free', 'Open Source'],
           ] as const).map(([value, label]) => (
-            <div key={label} className="text-center py-4 px-2 bg-gray-900 border border-gray-800 rounded-xl">
+            <div key={label} className="text-center py-4 px-2 card-glass">
               <div className="text-xl font-black text-orange-400">{value}</div>
               <div className="text-xs text-gray-500 mt-1 uppercase tracking-wide">{label}</div>
             </div>
@@ -115,7 +103,7 @@ export default function Home() {
       {/* Community + Donate */}
       <section className="container mx-auto px-4 pb-12">
         <div className="max-w-3xl mx-auto grid sm:grid-cols-2 gap-4">
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 text-center">
+          <div className="card-glass p-6 text-center">
             <h2 className="text-xl font-bold text-white mb-2">Community</h2>
             <p className="text-gray-400 text-sm mb-5">Join for updates, tips, and support.</p>
             <div className="flex flex-col gap-3 items-center">
@@ -123,7 +111,7 @@ export default function Home() {
               <SocialButton href="https://x.com/ProvenanceApp" label="Follow on X/Twitter" leftIcon={<XIcon className="w-5 h-5" />} variant="x" />
             </div>
           </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 text-center">
+          <div className="card-glass p-6 text-center">
             <h2 className="text-xl font-bold text-white mb-2">Support Development</h2>
             <p className="text-gray-400 text-sm mb-5">Help keep iFly free and actively developed.</p>
             <div className="flex flex-col gap-3 items-center">
@@ -138,7 +126,7 @@ export default function Home() {
       <VideoShowcase />
 
       {/* Screenshots */}
-      <section className="container mx-auto px-4 py-16">
+      <Section tone="ink-2">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold text-white mb-3">See It In Action</h2>
           <p className="text-gray-400 max-w-xl mx-auto">Classic Dreamcast games on your iPhone, iPad, and Apple TV.</p>
@@ -196,10 +184,10 @@ export default function Home() {
             ))}
           </div>
         </div>
-      </section>
+      </Section>
 
       {/* Features */}
-      <section className="border-t border-gray-800/60 py-16">
+      <section className="border-t border-white/10 py-16">
         <div className="container mx-auto px-4">
           <div className="text-center mb-10">
             <h2 className="text-3xl font-bold text-white mb-3">Built for Apple silicon</h2>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: "Privacy Policy - iFly",
@@ -9,17 +10,11 @@ export const metadata: Metadata = {
 
 export default function Privacy() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader title="Privacy Policy" subtitle="Effective date: May 31, 2026" />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-3xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-3 text-center">
-            Privacy Policy
-          </h1>
-          <p className="text-center text-gray-500 mb-10">
-            Effective date: May 31, 2026
-          </p>
-
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 space-y-8">
+          <div className="card-glass p-8 space-y-8">
             <section>
               <p className="text-gray-300 leading-relaxed">
                 iFly EMU does not collect any personally identifiable information.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: `${base}/`,           changeFrequency: 'weekly',  priority: 1.0 },
     { url: `${base}/downloads/`, changeFrequency: 'weekly',  priority: 0.9 },
+    { url: `${base}/guide/`,           changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${base}/guide/importing/`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/formats/`,   changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/bios/`,      changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/arcade/`,    changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/guide/systems/`,   changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${base}/guide/faq/`,       changeFrequency: 'monthly', priority: 0.6 },
     { url: `${base}/features/`,  changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/about/`,     changeFrequency: 'monthly', priority: 0.7 },
     { url: `${base}/support/`,   changeFrequency: 'monthly', priority: 0.6 },

--- a/src/app/status/StatusDashboard.tsx
+++ b/src/app/status/StatusDashboard.tsx
@@ -66,7 +66,7 @@ export default function StatusDashboard({ initialData }: { initialData?: StatusD
     : null;
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100 px-4 py-12">
+    <div className="min-h-screen bg-ink text-gray-100 px-4 py-12">
       <div className="max-w-2xl mx-auto space-y-8">
         <div>
           <h1 className="text-3xl font-bold text-white">Site Status</h1>
@@ -85,7 +85,7 @@ export default function StatusDashboard({ initialData }: { initialData?: StatusD
         {loading && (
           <div className="space-y-4 animate-pulse">
             {[...Array(3)].map((_, i) => (
-              <div key={i} className="bg-gray-900 border border-gray-800 rounded-2xl h-32" />
+              <div key={i} className="bg-gray-900 border border-white/10 rounded-2xl h-32" />
             ))}
           </div>
         )}
@@ -103,7 +103,7 @@ export default function StatusDashboard({ initialData }: { initialData?: StatusD
 
         {data && <>
         {/* Lighthouse */}
-        <section className="bg-gray-900 border border-gray-800 rounded-2xl p-6 space-y-4">
+        <section className="bg-gray-900 border border-white/10 rounded-2xl p-6 space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold">Lighthouse</h2>
             {lh?.report_url && (
@@ -128,7 +128,7 @@ export default function StatusDashboard({ initialData }: { initialData?: StatusD
         </section>
 
         {/* HTML & Links */}
-        <section className="bg-gray-900 border border-gray-800 rounded-2xl p-6">
+        <section className="bg-gray-900 border border-white/10 rounded-2xl p-6">
           <h2 className="text-lg font-semibold mb-4">HTML &amp; Links</h2>
           <div className="flex items-center gap-3">
             <StatusDot ok={data?.html_check.passed ?? null} />
@@ -143,7 +143,7 @@ export default function StatusDashboard({ initialData }: { initialData?: StatusD
         </section>
 
         {/* Security */}
-        <section className="bg-gray-900 border border-gray-800 rounded-2xl p-6 space-y-4">
+        <section className="bg-gray-900 border border-white/10 rounded-2xl p-6 space-y-4">
           <h2 className="text-lg font-semibold">Security</h2>
           <div className="space-y-3">
             <div className="flex items-center justify-between">

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import React from 'react';
 import SocialButton, { BmcIcon, PatreonIcon } from '@/components/SocialButton';
+import PageHeader from '@/components/ui/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Support',
@@ -10,15 +11,12 @@ export const metadata: Metadata = {
 
 export default function Support() {
   return (
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-ink">
+      <PageHeader title="Support" />
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-8 text-center">
-            Support
-          </h1>
-
           {/* FAQ Section */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-6">
               Frequently Asked Questions
             </h2>
@@ -43,14 +41,14 @@ export default function Support() {
           </div>
 
           {/* Contact Section */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-6">
               Getting Help
             </h2>
 
             <div className="grid md:grid-cols-2 gap-4">
               <a href="mailto:support@ifly-emu.com?subject=iFly%20Support"
-                 className="flex items-start gap-4 p-5 bg-gray-800/40 border border-gray-700/50 rounded-xl hover:border-gray-600 transition-colors group">
+                 className="flex items-start gap-4 p-5 card-glass group">
                 <div className="w-10 h-10 rounded-lg bg-orange-500/10 ring-1 ring-orange-500/20 flex items-center justify-center text-orange-400 shrink-0">
                   <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true"><path d="M1.5 8.67v8.58a3 3 0 0 0 3 3h15a3 3 0 0 0 3-3V8.67l-8.928 5.493a3 3 0 0 1-3.144 0L1.5 8.67Z"/><path d="M22.5 6.908V6.75a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3v.158l9.714 5.978a1.5 1.5 0 0 0 1.572 0L22.5 6.908Z"/></svg>
                 </div>
@@ -62,7 +60,7 @@ export default function Support() {
               </a>
 
               <a href="https://discord.gg/QF5ZjVT4Sa" target="_blank" rel="noopener noreferrer"
-                 className="flex items-start gap-4 p-5 bg-gray-800/40 border border-gray-700/50 rounded-xl hover:border-gray-600 transition-colors group">
+                 className="flex items-start gap-4 p-5 card-glass group">
                 <div className="w-10 h-10 rounded-lg bg-indigo-500/10 ring-1 ring-indigo-500/20 flex items-center justify-center text-indigo-400 shrink-0">
                   <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true"><path d="M20.317 4.369A19.791 19.791 0 0 0 16.558 3c-.2.355-.432.83-.593 1.205a18.27 18.27 0 0 0-3.93 0A11.09 11.09 0 0 0 11.443 3c-1.3.23-2.54.6-3.759 1.11C3.733 6.37 2.49 9.6 2.75 12.77c1.566 1.17 3.08 1.886 4.59 2.34.37-.51.702-1.055.989-1.627-.55-.21-1.078-.466-1.58-.768.132-.096.262-.196.386-.3 3.045 1.413 6.34 1.413 9.36 0 .127.104.255.204.386.3-.5.302-1.028.558-1.578.768.286.572.62 1.116.989 1.627 1.51-.454 3.023-1.17 4.59-2.34.38-4.513-1.48-7.317-3.615-8.401ZM9.58 12.66c-.623 0-1.132-.6-1.132-1.335 0-.735.505-1.34 1.132-1.34.631 0 1.14.606 1.132 1.34 0 .735-.505 1.334-1.132 1.334Zm4.85 0c-.623 0-1.132-.6-1.132-1.335 0-.735.505-1.34 1.132-1.34.631 0 1.14.606 1.132 1.34 0 .735-.505 1.334-1.132 1.334Z"/></svg>
                 </div>
@@ -76,7 +74,7 @@ export default function Support() {
           </div>
 
           {/* Donate Section (compact) */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8 mb-6">
+          <div className="card-glass p-8 mb-6">
             <h2 className="text-2xl font-semibold text-white mb-4">Support Development</h2>
             <p className="text-gray-400 mb-6">If you find iFly helpful, consider supporting the project.</p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
@@ -86,7 +84,7 @@ export default function Support() {
           </div>
 
           {/* Troubleshooting Section */}
-          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-8">
+          <div className="card-glass p-8">
             <h2 className="text-2xl font-semibold text-white mb-6">
               Troubleshooting Tips
             </h2>

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -1,187 +1,134 @@
 import React from 'react';
+import { FeatureCard } from '@/components/ui/Card';
 
-// Simple, consistent SVG icon set
-const IconWrap: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="inline-flex items-center justify-center w-11 h-11 rounded-xl bg-orange-500/10 text-orange-400 ring-1 ring-orange-500/20">
-    {children}
-  </div>
-);
-
-const ControllerIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M6 8h12a4 4 0 0 1 3.8 5.2l-1.1 3A3 3 0 0 1 17 18h-2l-2-2h-2l-2 2H7a3 3 0 0 1-3.7-1.8l-1.1-3A4 4 0 0 1 6 8Zm2 2v2H6v2h2v2h2v-2h2v-2h-2v-2H8Zm8 .5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"/>
-  </svg>
-);
-const PhoneIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M7 2h10a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Zm5 18a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z"/>
-  </svg>
-);
-const BoltIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M13 2 4 14h6l-1 8 9-12h-6l1-8Z"/>
-  </svg>
-);
-const SpeedIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M12 4a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7V4Zm6.2 5.2-4.9 4.9a2.5 2.5 0 1 1-3.5-3.5l4.9-4.9a8 8 0 0 1 3.5 3.5Z"/>
-  </svg>
-);
-const SparklesIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M11 2 9 7l-5 2 5 2 2 5 2-5 5-2-5-2-2-5Zm8 9-1 3-3 1 3 1 1 3 1-3 3-1-3-1-1-3Z"/>
-  </svg>
-);
-const CpuIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M9 3h6v2h3a2 2 0 0 1 2 2v3h2v2h-2v3a2 2 0 0 1-2 2h-3v2H9v-2H6a2 2 0 0 1-2-2v-3H2v-2h2V7a2 2 0 0 1 2-2h3V3Zm-1 6v6h8V9H8Z"/>
-  </svg>
-);
-const TargetIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M12 2v2a8 8 0 1 1-8 8H2a10 10 0 1 0 10-10Zm0 6a4 4 0 1 0 4 4h2a6 6 0 1 1-6-6v2Z"/>
-  </svg>
-);
-const CursorIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M3 2l8 20 2-7 7-2L3 2Z"/>
-  </svg>
-);
-const CloudIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M7 18h9a4 4 0 1 0-1.1-7.9A5 5 0 0 0 5 12a4 4 0 0 0 2 6Z"/>
-  </svg>
-);
-const SearchIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm8.7 13.3 3.3 3.3-1.4 1.4-3.3-3.3 1.4-1.4Z"/>
-  </svg>
-);
-const SaveIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M5 3h11l3 3v15a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm2 4v4h8V7H7Zm8 12v-5H9v5h6Z"/>
-  </svg>
-);
-const ChartIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6" aria-hidden="true">
-    <path d="M4 20V4h2v16H4Zm4 0v-9h2v9H8Zm4 0v-6h2v6h-2Zm4 0v-12h2v12h-2Z"/>
-  </svg>
+// Reuse a compact inline icon set (24x24, currentColor).
+const Icon = ({ d }: { d: string }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6" aria-hidden="true"><path d={d} /></svg>
 );
 
-export type Feature = {
-  title: string;
-  description: string;
-  icon?: React.ReactNode;
-};
+const ICONS = {
+  bolt: 'M13 2 4 14h6l-1 8 9-12h-6l1-8Z',
+  cpu: 'M9 3h6v2h3a2 2 0 0 1 2 2v3h2v2h-2v3a2 2 0 0 1-2 2h-3v2H9v-2H6a2 2 0 0 1-2-2v-3H2v-2h2V7a2 2 0 0 1 2-2h3V3Zm-1 6v6h8V9H8Z',
+  sparkles: 'M11 2 9 7l-5 2 5 2 2 5 2-5 5-2-5-2-2-5Zm8 9-1 3-3 1 3 1 1 3 1-3 3-1-3-1-1-3Z',
+  save: 'M5 3h11l3 3v15a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm2 4v4h8V7H7Zm8 12v-5H9v5h6Z',
+  cloud: 'M7 18h9a4 4 0 1 0-1.1-7.9A5 5 0 0 0 5 12a4 4 0 0 0 2 6Z',
+  controller: 'M6 8h12a4 4 0 0 1 3.8 5.2l-1.1 3A3 3 0 0 1 17 18h-2l-2-2h-2l-2 2H7a3 3 0 0 1-3.7-1.8l-1.1-3A4 4 0 0 1 6 8Zm2 2v2H6v2h2v2h2v-2h2v-2h-2v-2H8Zm8 .5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z',
+  target: 'M12 2v2a8 8 0 1 1-8 8H2a10 10 0 1 0 10-10Zm0 6a4 4 0 1 0 4 4h2a6 6 0 1 1-6-6v2Z',
+  phone: 'M7 2h10a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Zm5 18a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z',
+  chart: 'M4 20V4h2v16H4Zm4 0v-9h2v9H8Zm4 0v-6h2v6h-2Zm4 0v-12h2v12h-2Z',
+  search: 'M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm8.7 13.3 3.3 3.3-1.4 1.4-3.3-3.3 1.4-1.4Z',
+  network: 'M12 2a4 4 0 0 1 1 7.87V11h6a1 1 0 0 1 1 1v2.13a4 4 0 1 1-2 0V13h-5v1.13a4 4 0 1 1-2 0V13H6v1.13a4 4 0 1 1-2 0V12a1 1 0 0 1 1-1h6V9.87A4 4 0 0 1 12 2Z',
+} as const;
 
-export type FeaturesProps = {
-  compact?: boolean;
-  className?: string;
-};
+type Feature = { title: string; description: string; icon: React.ReactNode };
+type Group = { heading: string; items: Feature[] };
 
-const allFeatures: Feature[] = [
+const f = (title: string, description: string, d: string): Feature => ({ title, description, icon: <Icon d={d} /> });
+
+const GROUPS: Group[] = [
   {
-    title: 'MFi/PS/XBox/Switch Controller Support',
-    description:
-      'Use MFi/PS/XBox/Switch controllers for precise input and low-latency control.',
-    icon: <IconWrap><ControllerIcon /></IconWrap>,
+    heading: 'Performance & graphics',
+    items: [
+      f('JIT-less full speed', 'Custom Apple-silicon CPU work runs Dreamcast at full speed with no JIT. Upscales to 1440p or 4K on recent devices.', ICONS.cpu),
+      f('Custom Metal backend', 'A Metal renderer built for Apple GPUs, with HDR upscaling support.', ICONS.sparkles),
+      f('1K+ Metal shaders', 'A large native shader library for visual quality and effects.', ICONS.bolt),
+      f('Texture packs', 'Custom texture-pack support with a management UI, like Flycast.', ICONS.chart),
+      f('ProMotion support', 'High-refresh ProMotion rendering, or lock to the original refresh rate.', ICONS.phone),
+    ],
   },
   {
-    title: 'SwiftUI Interface',
-    description:
-      'Modern, native-first UI tailored for iPhone, iPad, and Apple TV with fast, polished navigation.',
-    icon: <IconWrap><PhoneIcon /></IconWrap>,
+    heading: 'VMU tooling',
+    items: [
+      f('Floating VMU window', 'Keep a live VMU on screen while you play.', ICONS.save),
+      f('VMU Watch companion', 'A live VMU viewer on Apple Watch.', ICONS.save),
+      f('Native VMU file manager', 'A Swift-native VMU manager with per-game and per-VMU backup and restore.', ICONS.save),
+    ],
   },
   {
-    title: 'Quick Toggles In-Game',
-    description:
-      'Handy performance and rendering quick toggles directly in the emulation scene.',
-    icon: <IconWrap><BoltIcon /></IconWrap>,
+    heading: 'Saves & sync',
+    items: [
+      f('iCloud sync', 'Saves, VMUs, and BIOS sync across devices over iCloud. ROMs stay local.', ICONS.cloud),
+      f('Off-thread auto-saves', 'Timed auto-saves serialize off the main thread, so emulation never stalls.', ICONS.save),
+      f('HLE & native BIOS', 'Run on the built-in HLE BIOS, or supply a real BIOS.', ICONS.cpu),
+    ],
   },
   {
-    title: 'Auto Artwork Loading',
-    description:
-      'Automatically loads artwork for games in the library.',
-    icon: <IconWrap><SpeedIcon /></IconWrap>,
+    heading: 'Input & controls',
+    items: [
+      f('External controllers + haptics', 'DualShock, DualSense, Xbox, Switch, and MFi controllers, with haptics.', ICONS.controller),
+      f('Jump Pack rumble', 'Jump Pack rumble maps to device haptics or controller rumble.', ICONS.controller),
+      f('Remappable + presets', 'Remap external controller buttons and save presets.', ICONS.target),
+      f('On-screen controls', 'Customizable, movable on-screen controls.', ICONS.target),
+      f('Keyboard & mouse', 'On-screen touch keyboard/mouse plus native Bluetooth keyboard, mouse, and Smart Keyboard where the OS supports it.', ICONS.phone),
+      f('Light gun & microphone', 'Touch light-gun input and native CoreAudio microphone input.', ICONS.target),
+      f('DeltaSkin / ManicSkin', 'Import DeltaSkin and ManicSkin controller skins.', ICONS.controller),
+    ],
   },
   {
-    title: '1k+ Native Metal Shaders',
-    description:
-      'Large library of native shaders for visual quality and performance on Apple GPUs.',
-    icon: <IconWrap><SparklesIcon /></IconWrap>,
+    heading: 'Connectivity & display',
+    items: [
+      f('External display', 'Output to an external display on iOS and iPadOS.', ICONS.phone),
+      f('DCNet & LAN', 'DCNet network and LAN support, matching Flycast.', ICONS.network),
+    ],
   },
   {
-    title: 'ARM64 Optimized Interpreter',
-    description:
-      'ARM64-specific optimizations in the CPU interpreter for faster JIT-less performance on iOS/tvOS.',
-    icon: <IconWrap><CpuIcon /></IconWrap>,
+    heading: 'Games & content',
+    items: [
+      f('Cheat database', 'In-app cheat-code database.', ICONS.sparkles),
+      f('RetroAchievements', 'RetroAchievements support.', ICONS.target),
+      f('Metadata lookup', 'Online game-metadata lookup for your library.', ICONS.search),
+      f('Per-game options', 'Tune options per game.', ICONS.chart),
+    ],
+  },
+  {
+    heading: 'Platform & import',
+    items: [
+      f('iOS, iPadOS, tvOS', 'One app across iPhone, iPad, and Apple TV.', ICONS.phone),
+      f('Recent-games widget', 'Quick-launch recent games from a Springboard widget.', ICONS.bolt),
+      f('Flexible import', 'WebDAV, HTTP, or Files.app import, plus drag-and-drop on iPad.', ICONS.cloud),
+    ],
   },
 ];
 
-// Additional extended features for the full page
-const extendedOnly: Feature[] = [
-  {
-    title: 'Enhanced Controller Mappings',
-    description:
-      'Thoughtful defaults incl. DualShock/DualSense touchpad → Wii IR, reliable turbo (hold all paddles).',
-    icon: <IconWrap><TargetIcon /></IconWrap>,
-  },
-  {
-    title: 'Automatic Cheat Download',
-    description:
-      'Automatically download cheats for games in the library.',
-    icon: <IconWrap><CursorIcon /></IconWrap>,
-  },
-  {
-    title: 'Artwork Search',
-    description:
-      'Search for artwork in the library from multiple sources.',
-    icon: <IconWrap><CloudIcon /></IconWrap>,
-  },
-  {
-    title: 'Smart Search & Filters',
-    description:
-      'Find by title, ID, maker, region, or path on iOS and tvOS with fast, stable results.',
-    icon: <IconWrap><SearchIcon /></IconWrap>,
-  },
-  {
-    title: 'Save States & Pause Menu',
-    description:
-      'Fast access to core actions with platform-appropriate UI and stable on‑screen controls toggle.',
-    icon: <IconWrap><SaveIcon /></IconWrap>,
-  },
-  {
-    title: 'Performance Controls',
-    description:
-      'Extensive performance controls to fine-tune smoothness vs. frame rate.',
-    icon: <IconWrap><ChartIcon /></IconWrap>,
-  },
+// Curated highlights for the homepage compact view.
+const HIGHLIGHTS: Feature[] = [
+  GROUPS[0].items[0], // JIT-less full speed
+  GROUPS[0].items[2], // 1K+ Metal shaders
+  GROUPS[1].items[0], // Floating VMU window
+  GROUPS[2].items[0], // iCloud sync
+  GROUPS[3].items[0], // External controllers + haptics
+  GROUPS[5].items[1], // RetroAchievements
 ];
 
-const Features: React.FC<FeaturesProps> = ({ compact = false, className }) => {
-  const items = compact ? allFeatures.slice(0, 6) : [...allFeatures, ...extendedOnly];
+export type FeaturesProps = { compact?: boolean; className?: string };
+
+export default function Features({ compact = false, className }: FeaturesProps) {
+  if (compact) {
+    return (
+      <div className={className}>
+        <div className="grid gap-5 md:grid-cols-3">
+          {HIGHLIGHTS.map((item) => (
+            <FeatureCard key={item.title} icon={item.icon} title={item.title}>{item.description}</FeatureCard>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={className}>
-      <div className={`grid gap-5 ${compact ? 'md:grid-cols-3' : 'md:grid-cols-2 lg:grid-cols-3'}`}>
-        {items.map((f) => (
-          <div key={f.title} className="flex flex-col gap-4 bg-gray-900 border border-gray-800 rounded-2xl p-6 hover:border-gray-700 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-black/20 transition-all duration-200">
-            <div aria-hidden="true">
-              {f.icon ?? (
-                <div className="inline-flex items-center justify-center w-11 h-11 rounded-xl bg-orange-500/10 text-orange-400 ring-1 ring-orange-500/20">
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2Z"/></svg>
-                </div>
-              )}
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold mb-1.5 text-white">{f.title}</h3>
-              <p className="text-gray-400 text-sm leading-relaxed">{f.description}</p>
+      <div className="space-y-12">
+        {GROUPS.map((group) => (
+          <div key={group.heading}>
+            <h3 className="mb-5 text-sm font-semibold uppercase tracking-wide text-orange-400">{group.heading}</h3>
+            <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+              {group.items.map((item) => (
+                <FeatureCard key={item.title} icon={item.icon} title={item.title}>{item.description}</FeatureCard>
+              ))}
             </div>
           </div>
         ))}
       </div>
     </div>
   );
-};
-
-export default Features;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ const ExternalFooterLink = ({ href, children }: { href: string; children: React.
 
 export default function Footer() {
   return (
-    <footer className="border-t border-gray-800 bg-gray-950 mt-16">
+    <footer className="border-t border-white/10 bg-ink mt-16">
       <div className="container mx-auto px-4 py-10">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-8">
 
@@ -33,6 +33,7 @@ export default function Footer() {
               <FooterLink href="/downloads/">Downloads</FooterLink>
               <FooterLink href="/testflight/">TestFlight Beta</FooterLink>
               <FooterLink href="/features/">Features</FooterLink>
+              <FooterLink href="/guide/">Guide</FooterLink>
               <FooterLink href="/about/">About</FooterLink>
             </div>
           </div>
@@ -41,6 +42,7 @@ export default function Footer() {
             <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Support</h3>
             <div className="flex flex-col gap-2">
               <FooterLink href="/support/">FAQ &amp; Help</FooterLink>
+              <FooterLink href="/guide/faq/">Import FAQ</FooterLink>
               <FooterLink href="/controllers/">Controllers</FooterLink>
               <FooterLink href="/donate/">Donate</FooterLink>
               <FooterLink href="/links/">Links</FooterLink>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,7 +47,7 @@ const Navigation = () => {
           {/* Desktop nav */}
           <div className="hidden md:flex items-baseline gap-1">
             {navItems.map(item => (
-              <Link key={item.href} href={item.href} className={linkClass(item.href)}>
+              <Link key={item.href} href={item.href} aria-current={isActive(item.href) ? 'page' : undefined} className={linkClass(item.href)}>
                 {item.label}
               </Link>
             ))}
@@ -80,6 +80,7 @@ const Navigation = () => {
             <Link
               key={item.href}
               href={item.href}
+              aria-current={isActive(item.href) ? 'page' : undefined}
               className={`block ${linkClass(item.href)}`}
               onClick={() => setMenuOpen(false)}
             >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,10 +7,10 @@ import { useState } from 'react';
 const navItems = [
   { href: '/',            label: 'Home' },
   { href: '/downloads/',  label: 'Downloads' },
-  { href: '/about/',      label: 'About' },
+  { href: '/guide/',      label: 'Guide' },
   { href: '/features/',   label: 'Features' },
+  { href: '/about/',      label: 'About' },
   { href: '/support/',    label: 'Support' },
-  { href: '/links/',      label: 'Links' },
   { href: '/donate/',     label: 'Donate' },
   { href: '/status/',     label: 'Status' },
 ];
@@ -22,15 +22,20 @@ const Navigation = () => {
   // Normalize both to have trailing slash (except root which is already '/')
   const normalizedPath = pathname === '/' ? '/' : (pathname.endsWith('/') ? pathname : `${pathname}/`);
 
+  const isActive = (href: string) => {
+    if (href === '/') return normalizedPath === '/';
+    return normalizedPath === href || normalizedPath.startsWith(href);
+  };
+
   const linkClass = (href: string) =>
     `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-      normalizedPath === href
-        ? 'bg-orange-700 text-white'
-        : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+      isActive(href)
+        ? 'btn-gradient text-white'
+        : 'text-gray-300 hover:bg-white/5 hover:text-white'
     }`;
 
   return (
-    <nav aria-label="Main navigation" className="bg-gray-900/95 backdrop-blur-sm text-white border-b border-gray-800 sticky top-0 z-50">
+    <nav aria-label="Main navigation" className="sticky top-0 z-50 border-b border-white/10 bg-ink/80 text-white backdrop-blur-md">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
 
@@ -70,7 +75,7 @@ const Navigation = () => {
 
       {/* Mobile menu */}
       {menuOpen && (
-        <div className="md:hidden border-t border-gray-700 bg-gray-900 px-4 py-3 space-y-1">
+        <div className="md:hidden border-t border-white/10 bg-ink/95 px-4 py-3 space-y-1">
           {navItems.map(item => (
             <Link
               key={item.href}

--- a/src/components/TestFlightGate.tsx
+++ b/src/components/TestFlightGate.tsx
@@ -38,7 +38,7 @@ export default function TestFlightGate({ testflightUrl, skipGate }: TestFlightGa
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 px-4 py-12">
+    <div className="min-h-screen bg-ink px-4 py-12">
       <div className="mx-auto max-w-2xl space-y-6">
         <header className="space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight text-white">Join the iFly TestFlight</h1>
@@ -48,7 +48,7 @@ export default function TestFlightGate({ testflightUrl, skipGate }: TestFlightGa
         </header>
 
         {!gatePassed ? (
-          <section className="rounded-2xl border border-gray-800 p-6 bg-gray-900">
+          <section className="card-glass p-6">
             <h2 className="text-xl font-medium mb-2 text-white">Help support the project</h2>
             <p className="text-sm text-gray-400 mb-4">
               Please follow <a href={TWITTER_URL} target="_blank" rel="noreferrer noopener" className="underline underline-offset-4">@provenanceapp</a> on X (Twitter) to stay updated on releases and development. Once followed, click “I followed” below. If you prefer not to follow, you can still proceed.
@@ -79,7 +79,7 @@ export default function TestFlightGate({ testflightUrl, skipGate }: TestFlightGa
             </div>
           </section>
         ) : (
-          <section className="rounded-2xl border border-gray-800 p-6 bg-gray-900">
+          <section className="card-glass p-6">
             <h2 className="text-xl font-medium mb-2 text-white">You’re in</h2>
             <p className="text-sm text-gray-400 mb-4">
               Click below to open the TestFlight invite. If the build is full, try again later.
@@ -109,7 +109,7 @@ export default function TestFlightGate({ testflightUrl, skipGate }: TestFlightGa
           </p>
         </section>
 
-        <section className="rounded-2xl border border-gray-800 p-6 bg-gray-900">
+        <section className="card-glass p-6">
           <h2 className="text-xl font-medium mb-2 text-white">Support Development</h2>
           <p className="text-sm text-gray-400 mb-4">
             If you find iFly helpful, consider supporting ongoing development. Thank you!

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React, { useState } from 'react';
+
+export type AccordionItemData = { q: string; a: React.ReactNode };
+
+export default function Accordion({ items }: { items: AccordionItemData[] }) {
+  const [open, setOpen] = useState<number | null>(null);
+  return (
+    <div className="divide-y divide-white/10 overflow-hidden rounded-xl border border-white/10">
+      {items.map((item, i) => {
+        const isOpen = open === i;
+        return (
+          <div key={i} className="bg-white/[0.02]">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+              aria-expanded={isOpen}
+              onClick={() => setOpen(isOpen ? null : i)}
+            >
+              <span className="font-medium text-white">{item.q}</span>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                className={`h-5 w-5 shrink-0 text-orange-400 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+              </svg>
+            </button>
+            {isOpen && <div className="px-5 pb-5 text-sm leading-relaxed text-gray-300">{item.a}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -10,10 +10,14 @@ export default function Accordion({ items }: { items: AccordionItemData[] }) {
     <div className="divide-y divide-white/10 overflow-hidden rounded-xl border border-white/10">
       {items.map((item, i) => {
         const isOpen = open === i;
+        const buttonId = `accordion-button-${i}`;
+        const panelId = `accordion-panel-${i}`;
         return (
           <div key={i} className="bg-white/[0.02]">
             <button
               type="button"
+              id={buttonId}
+              aria-controls={panelId}
               className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
               aria-expanded={isOpen}
               onClick={() => setOpen(isOpen ? null : i)}
@@ -30,7 +34,15 @@ export default function Accordion({ items }: { items: AccordionItemData[] }) {
                 <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
               </svg>
             </button>
-            {isOpen && <div className="px-5 pb-5 text-sm leading-relaxed text-gray-300">{item.a}</div>}
+            <div
+              id={panelId}
+              role="region"
+              aria-labelledby={buttonId}
+              hidden={!isOpen}
+              className="px-5 pb-5 text-sm leading-relaxed text-gray-300"
+            >
+              {item.a}
+            </div>
           </div>
         );
       })}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const toneClass = {
+  default: 'bg-gray-800 text-gray-300 border-gray-700',
+  required: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  optional: 'bg-gray-800 text-gray-400 border-gray-700',
+} as const;
+
+export function Badge({ children, tone = 'default' }: { children: React.ReactNode; tone?: keyof typeof toneClass }) {
+  return (
+    <span className={`inline-block rounded-full border px-3 py-1 text-xs font-medium ${toneClass[tone]}`}>
+      {children}
+    </span>
+  );
+}
+
+export function Pill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-block rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-sm text-gray-300">
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Callout.tsx
+++ b/src/components/ui/Callout.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const variantClass = {
+  tip: 'border-orange-500/30 bg-orange-500/[0.06]',
+  warn: 'border-amber-500/30 bg-amber-500/[0.06]',
+  info: 'border-sky-500/30 bg-sky-500/[0.06]',
+} as const;
+
+const labelClass = {
+  tip: 'text-orange-300',
+  warn: 'text-amber-300',
+  info: 'text-sky-300',
+} as const;
+
+export default function Callout({
+  variant = 'info',
+  title,
+  children,
+}: {
+  variant?: keyof typeof variantClass;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`my-6 rounded-xl border p-4 ${variantClass[variant]}`}>
+      {title && <p className={`mb-1 text-sm font-semibold ${labelClass[variant]}`}>{title}</p>}
+      <div className="text-sm leading-relaxed text-gray-300">{children}</div>
+    </div>
+  );
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return <div className={`card-glass p-6 ${className}`}>{children}</div>;
+}
+
+export function FeatureCard({
+  icon,
+  title,
+  children,
+  className = '',
+}: {
+  icon?: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`card-glass group flex flex-col gap-4 p-6 ${className}`}>
+      {icon && (
+        <div
+          aria-hidden="true"
+          className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-orange-500/10 text-orange-400 ring-1 ring-orange-500/20 transition-colors duration-300 group-hover:bg-[image:var(--gradient-primary)] group-hover:text-white group-hover:ring-transparent"
+        >
+          {icon}
+        </div>
+      )}
+      <div>
+        <h3 className="mb-1.5 text-lg font-semibold text-white">{title}</h3>
+        <p className="text-sm leading-relaxed text-gray-400">{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/GradientButton.tsx
+++ b/src/components/ui/GradientButton.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import React from 'react';
+
+type GradientButtonProps = {
+  href: string;
+  children: React.ReactNode;
+  external?: boolean;
+  className?: string;
+  variant?: 'solid' | 'outline';
+};
+
+const base = 'inline-flex items-center justify-center gap-2 px-8 py-3 font-semibold text-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 focus-visible:ring-offset-ink';
+const solid = 'btn-gradient';
+const outline = 'rounded-full border border-orange-500/50 text-orange-300 hover:bg-orange-500/10 transition-colors';
+
+export default function GradientButton({ href, children, external = false, className = '', variant = 'solid' }: GradientButtonProps) {
+  const classes = `${base} ${variant === 'solid' ? solid : outline} ${className}`;
+  if (external) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={classes}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className={classes}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/ui/GridHero.tsx
+++ b/src/components/ui/GridHero.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function GridHero({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return (
+    <section className={`relative overflow-hidden ${className}`}>
+      <div className="grid-overlay" aria-hidden="true" />
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
+        <div className="absolute left-1/2 top-0 h-[600px] w-[900px] -translate-x-1/2 rounded-full bg-orange-500/10 blur-3xl" />
+        <div className="absolute left-1/2 top-20 h-[400px] w-[400px] -translate-x-1/2 rounded-full bg-orange-600/5 blur-2xl" />
+      </div>
+      <div className="container relative mx-auto px-4">{children}</div>
+    </section>
+  );
+}

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import GridHero from './GridHero';
+
+export default function PageHeader({
+  title,
+  subtitle,
+  eyebrow,
+}: {
+  title: string;
+  subtitle?: string;
+  eyebrow?: string;
+}) {
+  return (
+    <GridHero className="pt-16 pb-10 text-center">
+      <div className="mx-auto max-w-3xl">
+        {eyebrow && <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-orange-400">{eyebrow}</p>}
+        <h1 className="text-4xl font-black tracking-tight text-white md:text-5xl">{title}</h1>
+        {subtitle && <p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-gray-400">{subtitle}</p>}
+      </div>
+    </GridHero>
+  );
+}

--- a/src/components/ui/Screenshot.tsx
+++ b/src/components/ui/Screenshot.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image';
+import React from 'react';
+
+type ScreenshotProps = {
+  src?: string;
+  alt: string;
+  caption?: string;
+  width: number;
+  height: number;
+  className?: string;
+};
+
+export default function Screenshot({ src, alt, caption, width, height, className = '' }: ScreenshotProps) {
+  return (
+    <figure className={className}>
+      {src ? (
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          className="rounded-xl border border-white/10 shadow-lg"
+        />
+      ) : (
+        <div
+          role="img"
+          aria-label={`Placeholder: ${alt}`}
+          style={{ aspectRatio: `${width} / ${height}` }}
+          className="flex w-full flex-col items-center justify-center gap-1 rounded-xl border border-dashed border-white/15 bg-white/[0.02] p-6 text-center"
+        >
+          <span className="text-xs font-medium uppercase tracking-wide text-gray-500">Screenshot</span>
+          <span className="text-sm text-gray-400">{alt}</span>
+          <span className="text-[11px] text-gray-600">{width}×{height}</span>
+        </div>
+      )}
+      {caption && <figcaption className="mt-2 text-center text-xs text-gray-500">{caption}</figcaption>}
+    </figure>
+  );
+}

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const toneClass = {
+  ink: 'bg-ink',
+  'ink-2': 'bg-ink-2',
+  'ink-3': 'bg-ink-3',
+} as const;
+
+type SectionProps = {
+  children: React.ReactNode;
+  className?: string;
+  tone?: keyof typeof toneClass;
+  id?: string;
+};
+
+export default function Section({ children, className = '', tone, id }: SectionProps) {
+  return (
+    <section id={id} className={`${tone ? toneClass[tone] : ''} py-16 ${className}`}>
+      <div className="container mx-auto px-4">{children}</div>
+    </section>
+  );
+}

--- a/src/lib/buildParser.ts
+++ b/src/lib/buildParser.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import plist from 'plist';
+import * as plist from 'plist';
 
 export interface BuildVersion {
   version: string;


### PR DESCRIPTION
Restyles the iFly site with a provenance-emu-inspired retrowave design system (kept the orange brand) and adds a multi-page `/guide` section. Prep for the first App Store release.

## Design system
- Token layer in `globals.css`: primary gradient `linear-gradient(135deg,#ffab40,#ff6900 50%,#d64500)`, layered near-black backgrounds (`bg-ink`/`ink-2`/`ink-3`), animated drifting-grid overlay, glass cards, gradient pill buttons, `prefers-reduced-motion` guards.
- Reusable components in `src/components/ui/`: `GridHero`, `PageHeader`, `Section`, `Card`/`FeatureCard`, `GradientButton`, `Badge`/`Pill`, `Callout`, `Screenshot` (placeholder-aware), `Accordion`.
- Glassmorphism nav + footer; added **Guide** to the nav with `/guide/*` sub-route highlighting.

## New `/guide` section
Client layout with sticky sub-nav + prev/next over 7 pages, each a server component with its own canonical metadata:
- **Importing Games** — Files app, drag-and-drop, Wi-Fi WebDAV upload, `ifly://` scheme; extraction behavior.
- **Supported Formats** — full extension table; prefer `.chd`/`.cdi` over `.gdi`.
- **BIOS Setup** — Dreamcast needs no BIOS (HLE Reios); arcade BIOS matrix.
- **Arcade & Naomi Rips** — iFly's edge over stock Flycast (decrypted single-cart `.bin`, multi-track GD-ROM dumps, Naomi GD-cartridge zip+CHD companions).
- **Systems** — Dreamcast, Naomi, Naomi 2, Atomiswave, System SP, game-specific boards.
- **FAQ & Troubleshooting** — accordion.

All guide content is source-derived from the iFly repo.

## Features + restyle
- Rewrote `Features.tsx` into a grouped set surfacing the differentiators: JIT-less full-speed / 1440p–4K on Apple silicon, 1K+ Metal shaders, VMU tooling (floating window, Watch companion, native file manager), off-main-thread auto-saves, iCloud sync (saves/VMUs/BIOS, not ROMs), RetroAchievements, DCNet/LAN, DeltaSkin/ManicSkin, and more. Curated highlights on the homepage.
- Restyled the homepage and all 12 existing pages onto the design system. Screenshot placeholders are in place site-wide for real images to drop in later.
- Added the 7 guide routes to `sitemap.ts`.

## Verification
`npm run type-check`, `npm run lint` (0 errors), and `npm run build` all pass — 28 routes prerender for the static export. No new CSP origins introduced.

Design spec and implementation plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)