### PR TITLE
perf: remove unused GA preconnect hints and blur-filter hero glow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -112,10 +112,6 @@ export default function RootLayout({
       <head>
         <meta httpEquiv="Content-Security-Policy" content={CSP} />
         <meta name="referrer" content="strict-origin-when-cross-origin" />
-        <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
-        <link rel="preconnect" href="https://www.google-analytics.com" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-        <link rel="dns-prefetch" href="https://www.google-analytics.com" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/src/components/ui/GridHero.tsx
+++ b/src/components/ui/GridHero.tsx
@@ -5,8 +5,9 @@ export default function GridHero({ children, className = '' }: { children: React
     <section className={`relative overflow-hidden ${className}`}>
       <div className="grid-overlay" aria-hidden="true" />
       <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
-        <div className="absolute left-1/2 top-0 h-[600px] w-[900px] -translate-x-1/2 rounded-full bg-orange-500/10 blur-3xl" />
-        <div className="absolute left-1/2 top-20 h-[400px] w-[400px] -translate-x-1/2 rounded-full bg-orange-600/5 blur-2xl" />
+        {/* Radial-gradient glow instead of filter:blur() — same look, no expensive paint cost on the LCP-critical hero */}
+        <div className="absolute left-1/2 top-0 h-[600px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(ellipse_at_center,rgba(249,115,22,0.10),transparent_70%)]" />
+        <div className="absolute left-1/2 top-20 h-[400px] w-[400px] -translate-x-1/2 rounded-full bg-[radial-gradient(ellipse_at_center,rgba(234,88,12,0.05),transparent_70%)]" />
       </div>
       <div className="container relative mx-auto px-4">{children}</div>
     </section>


### PR DESCRIPTION
## Summary
- Removed unused `preconnect`/`dns-prefetch` hints for Google Analytics domains in `layout.tsx` — GA isn't actually loaded (CSP `script-src 'self'` blocks it anyway), so these were opening unused early connections during page load.
- Replaced `filter: blur()` ambient-glow elements in the homepage hero (`GridHero.tsx`) with an equivalent `radial-gradient` background — same visual, no expensive blur compositing cost on the LCP-critical above-the-fold content.

Fixes #80.

## Test plan
- [ ] CI build/lint pass
- [ ] Re-run Lighthouse audit and confirm performance score ≥ 70
- [ ] Visually check homepage hero glow looks unchanged

Generated with [Claude Code](https://claude.ai/code)