### PR TITLE
fix: defer itch.io embed loading to improve Lighthouse performance

### DIFF
--- a/src/components/ItchIoEmbed.tsx
+++ b/src/components/ItchIoEmbed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 export type ItchIoEmbedProps = {
   itchId: string;
@@ -9,32 +9,19 @@ export type ItchIoEmbedProps = {
   className?: string;
 };
 
+// Click-to-load facade — the itch.io widget is a third-party iframe that pulls in
+// its own CSS/JS/images. Loading it eagerly (even via IntersectionObserver, which
+// can still fire during an automated audit with no real scrolling) adds third-party
+// weight to the critical path and hurts Lighthouse performance (TBT, JS/CSS payload).
+// Deferring until a real click guarantees it never loads during a passive page load.
 const ItchIoEmbed: React.FC<ItchIoEmbedProps> = ({ itchId, linkColor = '#5b96fa', title, className }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: '200px' },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
+  const [loaded, setLoaded] = useState(false);
   const src = `https://itch.io/embed/${itchId}?link_color=${encodeURIComponent(linkColor.replace('#', ''))}`;
   const anchorTitle = title ?? 'iFly - Dreamcast Emulator for iOS and tvOS by Provenance EMU';
 
-  return (
-    <div ref={containerRef} className="w-full overflow-x-auto" style={{ minHeight: '167px' }}>
-      {visible && (
+  if (loaded) {
+    return (
+      <div className="w-full overflow-x-auto" style={{ minHeight: '167px' }}>
         <iframe
           title={anchorTitle}
           src={src}
@@ -43,8 +30,20 @@ const ItchIoEmbed: React.FC<ItchIoEmbedProps> = ({ itchId, linkColor = '#5b96fa'
           style={{ border: 0, maxWidth: '100%' }}
           className={className}
         />
-      )}
-    </div>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setLoaded(true)}
+      className={`w-full max-w-[552px] flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-6 text-sm text-gray-300 hover:bg-white/10 hover:text-white transition-colors ${className ?? ''}`}
+      style={{ minHeight: '167px' }}
+      aria-label={`Load the itch.io widget for ${anchorTitle}`}
+    >
+      Show itch.io widget
+    </button>
   );
 };
 


### PR DESCRIPTION
## Summary
- The itch.io widget on the homepage auto-loaded its third-party iframe (with its own CSS/JS/images) via an `IntersectionObserver` (200px rootMargin). On the mobile viewport Lighthouse audits, the Download section sits close enough to the fold that the observer can still fire during a passive page load (no real scrolling happens during an automated audit), pulling third-party weight onto the critical path and inflating Total Blocking Time.
- Replaced it with a click-to-load facade: a lightweight button now renders in place of the iframe, and the real itch.io embed only mounts after a user click — guaranteeing zero third-party cost during any passive page load.

Fixes #85

Generated with [Claude Code](https://claude.ai/code)